### PR TITLE
Support querying for `&dyn Trait` and `&mut dyn Trait`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ If you find a bug, please [open an issue](https://github.com/JoJoJet/bevy-trait-
 
 ```rust
 use bevy::prelude::*;
-use bevy_trait_query::{impl_trait_query, RegisterExt};
 
 // Some trait that we wish to use in queries.
 pub trait Tooltip: 'static {
@@ -29,19 +28,23 @@ pub trait Tooltip: 'static {
 }
 
 // Add the necessary impls for querying.
-impl_trait_query!(Tooltip);
+bevy_trait_query::impl_trait_query!(Tooltip);
+
+// Define some custom components.
 
 #[derive(Component)]
 struct Person(String);
+
+#[derive(Component)]
+struct Monster;
+
+// Implement the trait for these components.
 
 impl Tooltip for Person {
     fn tooltip(&self) -> &str {
         &self.0
     }
 }
-
-#[derive(Component)]
-struct Monster;
 
 impl Tooltip for Monster {
     fn tooltip(&self) -> &str {
@@ -50,8 +53,12 @@ impl Tooltip for Monster {
 }
 
 fn main() {
+    // We must import this trait in order to register our trait impls.
+    // If we don't register them, they will be invisible to the game engine.
+    use bevy_trait_query::RegisterExt;
+
     App::new()
-        // We must register each trait impl, otherwise they are invisible to the game engine.
+        // Register our components.
         .register_component_as::<dyn Tooltip, Person>()
         .register_component_as::<dyn Tooltip, Monster>()
         .add_startup_system(setup)

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ fn show_tooltips(
     }
 }
 
-
 use bevy_trait_query::One;
 fn show_tooltips_one(
     // If you expect to only have one trait impl per entity, you should use the `One` filter.

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ fn main() {
         .register_component_as::<dyn Tooltip, Person>()
         .register_component_as::<dyn Tooltip, Monster>()
         .add_startup_system(setup)
-        .add_system(show_tooltip)
-        .add_system(show_all_tooltips)
+        .add_system(show_tooltips)
+        .add_system(show_tooltips_one)
 }
 
 fn setup(mut commands: Commands) {

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ fn show_tooltips(
 use bevy_trait_query::One;
 fn show_tooltips_one(
     // If you expect to only have one trait impl per entity, you should use the `One` filter.
-    // This is significantly more efficient than querying for all trait impls.
+    // This is significantly more efficient than iterating over all trait impls.
     query: Query<One<&dyn Tooltip>>,
 ) {
     for tooltip: &dyn Tooltip in &query {

--- a/README.md
+++ b/README.md
@@ -64,37 +64,28 @@ fn setup(mut commands: Commands) {
     commands.spawn().insert(Monster);
 }
 
-use bevy_trait_query::One;
-fn show_tooltip(
-    // Query for entities with exactly one component implementing the trait.
-    query: Query<One<&dyn Tooltip>>,
-    // ...
+fn show_tooltips(
+    // Query for entities with components implementing the trait.
+    query: Query<&dyn Tooltip>,
 ) {
-    for tt in &query {
-        let mouse_hovered = {
-            // ...
-        };
-        if mouse_hovered {
-            println!("{}", tt.tooltip());
+    for entity_tooltips in &query {
+        // It's possible for an entity to have more than one component implementing the trait,
+        // so we must iterate over all possible components for each entity.
+        for tooltip: &dyn Tooltip in entity_tooltips {
+            println!("Hovering: {}", tooltip.tooltip());
         }
     }
 }
 
-use bevy_trait_query::All;
-fn show_all_tooltips(
-    // Query that returns all trait impls for each entity.
-    query: Query<All<&dyn Tooltip>>,
+
+use bevy_trait_query::One;
+fn show_tooltips_one(
+    // If you expect to only have one trait impl per entity, you should use the `One` filter.
+    // This is significantly more efficient than querying for all trait impls.
+    query: Query<One<&dyn Tooltip>>,
 ) {
-    for tooltips in &query {
-        // Loop over all tooltip impls for this entity.
-        for tt in tooltips {
-            let mouse_hovered = {
-                // ...
-            };
-            if mouse_hovered {
-                println!("{}", tt.tooltip());
-            }
-        }
+    for tooltip: &dyn Tooltip in &query {
+        println!("Hovering: {}", tooltip.tooltip());
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -30,15 +30,13 @@ pub trait Tooltip: 'static {
 // Add the necessary impls for querying.
 bevy_trait_query::impl_trait_query!(Tooltip);
 
-// Define some custom components.
+// Define some custom components which will implement the trait.
 
 #[derive(Component)]
 struct Person(String);
 
 #[derive(Component)]
 struct Monster;
-
-// Implement the trait for these components.
 
 impl Tooltip for Person {
     fn tooltip(&self) -> &str {

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ fn show_tooltips(
     for entity_tooltips in &query {
         // It's possible for an entity to have more than one component implementing the trait,
         // so we must iterate over all possible components for each entity.
-        for tooltip: &dyn Tooltip in entity_tooltips {
+        for tooltip in entity_tooltips {
             println!("Hovering: {}", tooltip.tooltip());
         }
     }
@@ -88,7 +88,7 @@ fn show_tooltips_one(
     // This is significantly more efficient than iterating over all trait impls.
     query: Query<One<&dyn Tooltip>>,
 ) {
-    for tooltip: &dyn Tooltip in &query {
+    for tooltip in &query {
         println!("Hovering: {}", tooltip.tooltip());
     }
 }

--- a/benches/all.rs
+++ b/benches/all.rs
@@ -42,7 +42,7 @@ impl Messages for RecB {
     }
 }
 
-pub struct Benchmark<'w>(World, QueryState<All<&'w dyn Messages>>, Vec<usize>);
+pub struct Benchmark<'w>(World, QueryState<&'w dyn Messages>, Vec<usize>);
 
 impl<'w> Benchmark<'w> {
     // Each entity only has one component in practice.
@@ -63,7 +63,7 @@ impl<'w> Benchmark<'w> {
                 .insert_bundle((Name::new("Hello"), RecB { messages: vec![] }));
         }
 
-        let query = world.query::<All<&dyn Messages>>();
+        let query = world.query();
         Self(world, query, default())
     }
     fn multiple() -> Self {
@@ -80,7 +80,7 @@ impl<'w> Benchmark<'w> {
             ));
         }
 
-        let query = world.query::<All<&dyn Messages>>();
+        let query = world.query();
         Self(world, query, default())
     }
     // Queries with only one, and queries with mutliple.
@@ -108,7 +108,7 @@ impl<'w> Benchmark<'w> {
             ));
         }
 
-        let query = world.query::<All<&dyn Messages>>();
+        let query = world.query();
         Self(world, query, default())
     }
 

--- a/benches/fragmented.rs
+++ b/benches/fragmented.rs
@@ -99,7 +99,7 @@ pub fn one(c: &mut Criterion) {
 }
 pub fn all(c: &mut Criterion) {
     let mut benchmark = Benchmark::new();
-    let mut query = benchmark.0.query::<All<&mut dyn Messages>>();
+    let mut query = benchmark.0.query::<&mut dyn Messages>();
     let mut output = Vec::new();
     c.bench_function("All<> - fragmented", |b| {
         b.iter(|| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,8 +58,8 @@
 //!         .register_component_as::<dyn Tooltip, Person>()
 //!         .register_component_as::<dyn Tooltip, Monster>()
 //!         .add_startup_system(setup)
-//!         .add_system(show_tooltip)
-//!         .add_system(show_all_tooltips)
+//!         .add_system(show_tooltips)
+//!         .add_system(show_tooltips_one)
 //!         # .update();
 //! }
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,6 @@
 //!     }
 //! }
 //!
-//!
 //! use bevy_trait_query::One;
 //! fn show_tooltips_one(
 //!     // If you expect to only have one trait impl per entity, you should use the `One` filter.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,39 +61,28 @@
 //!     commands.spawn().insert(Monster);
 //! }
 //!
-//! use bevy_trait_query::One;
-//! fn show_tooltip(
-//!     // Query for entities with exactly one component implementing the trait.
-//!     query: Query<One<&dyn Tooltip>>,
-//!     // ...
+//! fn show_tooltips(
+//!     // Query for entities with components implementing the trait.
+//!     query: Query<&dyn Tooltip>,
 //! ) {
-//!     for tt in &query {
-//!         let mouse_hovered = {
-//!             // ...
-//!             # true
-//!         };
-//!         if mouse_hovered {
-//!             println!("{}", tt.tooltip());
+//!     for entity_tooltips in &query {
+//!         // It's possible for an entity to have more than one component implementing the trait,
+//!         // so we must iterate over all possible components for each entity.
+//!         for tooltip: &dyn Tooltip in entity_tooltips {
+//!             println!("Hovering: {}", tooltip.tooltip());
 //!         }
 //!     }
 //! }
 //!
-//! use bevy_trait_query::All;
-//! fn show_all_tooltips(
-//!     // Query that returns all trait impls for each entity.
-//!     query: Query<All<&dyn Tooltip>>,
+//!
+//! use bevy_trait_query::One;
+//! fn show_tooltips_one(
+//!     // If you expect to only have one trait impl per entity, you should use the `One` filter.
+//!     // This is significantly more efficient than querying for all trait impls.
+//!     query: Query<One<&dyn Tooltip>>,
 //! ) {
-//!     for tooltips in &query {
-//!         // Loop over all tooltip impls for this entity.
-//!         for tt in tooltips {
-//!             let mouse_hovered = {
-//!                 // ...
-//!                 # true
-//!             };
-//!             if mouse_hovered {
-//!                 println!("{}", tt.tooltip());
-//!             }
-//!         }
+//!     for tooltip: &dyn Tooltip in &query {
+//!         println!("Hovering: {}", tooltip.tooltip());
 //!     }
 //! }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,15 +26,13 @@
 //! // Add the necessary impls for querying.
 //! bevy_trait_query::impl_trait_query!(Tooltip);
 //!
-//! // Define some custom components.
+//! // Define some custom components which will implement the trait.
 //!
 //! #[derive(Component)]
 //! struct Person(String);
 //!
 //! #[derive(Component)]
 //! struct Monster;
-//!
-//! // Implement the trait for these components.
 //!
 //! impl Tooltip for Person {
 //!     fn tooltip(&self) -> &str {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@
 //!     for entity_tooltips in &query {
 //!         // It's possible for an entity to have more than one component implementing the trait,
 //!         // so we must iterate over all possible components for each entity.
-//!         for tooltip: &dyn Tooltip in entity_tooltips {
+//!         for tooltip in entity_tooltips {
 //!             println!("Hovering: {}", tooltip.tooltip());
 //!         }
 //!     }
@@ -85,7 +85,7 @@
 //!     // This is significantly more efficient than iterating over all trait impls.
 //!     query: Query<One<&dyn Tooltip>>,
 //! ) {
-//!     for tooltip: &dyn Tooltip in &query {
+//!     for tooltip in &query {
 //!         println!("Hovering: {}", tooltip.tooltip());
 //!     }
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@
 //! use bevy_trait_query::One;
 //! fn show_tooltips_one(
 //!     // If you expect to only have one trait impl per entity, you should use the `One` filter.
-//!     // This is significantly more efficient than querying for all trait impls.
+//!     // This is significantly more efficient than iterating over all trait impls.
 //!     query: Query<One<&dyn Tooltip>>,
 //! ) {
 //!     for tooltip: &dyn Tooltip in &query {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@
 //!
 //! ```
 //! use bevy::prelude::*;
-//! use bevy_trait_query::{impl_trait_query, RegisterExt};
 //!
 //! // Some trait that we wish to use in queries.
 //! pub trait Tooltip: 'static {
@@ -25,19 +24,23 @@
 //! }
 //!
 //! // Add the necessary impls for querying.
-//! impl_trait_query!(Tooltip);
+//! bevy_trait_query::impl_trait_query!(Tooltip);
+//!
+//! // Define some custom components.
 //!
 //! #[derive(Component)]
 //! struct Person(String);
+//!
+//! #[derive(Component)]
+//! struct Monster;
+//!
+//! // Implement the trait for these components.
 //!
 //! impl Tooltip for Person {
 //!     fn tooltip(&self) -> &str {
 //!         &self.0
 //!     }
 //! }
-//!
-//! #[derive(Component)]
-//! struct Monster;
 //!
 //! impl Tooltip for Monster {
 //!     fn tooltip(&self) -> &str {
@@ -46,8 +49,12 @@
 //! }
 //!
 //! fn main() {
+//!     // We must import this trait in order to register our trait impls.
+//!     // If we don't register them, they will be invisible to the game engine.
+//!     use bevy_trait_query::RegisterExt;
+//!
 //!     App::new()
-//!         // We must register each trait impl, otherwise they are invisible to the game engine.
+//!         // Register our components.
 //!         .register_component_as::<dyn Tooltip, Person>()
 //!         .register_component_as::<dyn Tooltip, Monster>()
 //!         .add_startup_system(setup)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -165,7 +165,7 @@ fn all1() {
 }
 
 // Prints the name and age of every `Person`.
-fn print_all_info(people: Query<All<&dyn Person>>, mut output: ResMut<Output>) {
+fn print_all_info(people: Query<&dyn Person>, mut output: ResMut<Output>) {
     output.0.push("All people:".to_string());
     for all in &people {
         for person in all {
@@ -177,7 +177,7 @@ fn print_all_info(people: Query<All<&dyn Person>>, mut output: ResMut<Output>) {
     output.0.push(default());
 }
 
-fn age_up_fem(mut q: Query<All<&mut dyn Person>, With<Fem>>) {
+fn age_up_fem(mut q: Query<&mut dyn Person, With<Fem>>) {
     for all in &mut q {
         for mut p in all {
             let age = p.age();
@@ -186,7 +186,7 @@ fn age_up_fem(mut q: Query<All<&mut dyn Person>, With<Fem>>) {
     }
 }
 
-fn age_up_not(mut q: Query<All<&mut dyn Person>, Without<Fem>>) {
+fn age_up_not(mut q: Query<&mut dyn Person, Without<Fem>>) {
     for all in &mut q {
         for mut p in all {
             let age = p.age();
@@ -266,7 +266,7 @@ fn sparse1() {
     );
 }
 
-fn print_messages(q: Query<All<&dyn Messages>>, mut output: ResMut<Output>) {
+fn print_messages(q: Query<&dyn Messages>, mut output: ResMut<Output>) {
     output.0.push("New frame:".to_owned());
     for (i, all) in q.iter().enumerate() {
         for msgs in all {


### PR DESCRIPTION
The default functionality for trait queries is to iterate over all matching components per entity. The `One` filter can be used when only one trait impl should exist per entity.