### PR TITLE
Clarify behavior of `register_component_as`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,12 @@ pub trait TraitQueryMarker<Trait: ?Sized + TraitQuery> {
 
 /// Extension methods for registering components with trait queries.
 pub trait RegisterExt {
+    /// Allows a component to be used in trait queries.
+    /// Calling this multiple times with the same arguments will do nothing on subsequent calls.
+    ///
+    /// # Panics
+    /// If this function is called after the simulation starts for a given [`World`].
+    /// Due to engine limitations, registering new trait impls after the game starts cannot be supported.
     fn register_component_as<Trait: ?Sized + TraitQuery, C: Component>(&mut self) -> &mut Self
     where
         (C,): TraitQueryMarker<Trait, Covered = C>;


### PR DESCRIPTION
Add documentation to the `register_component_as` extension method, clarifying the behavior of double registration and late registration.

Added a test case for multiply registered impls.

Fixes #3.