### PR TITLE
Fix change ticks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy-trait-query"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 description = "Implementation of trait queries for the bevy game engine"

--- a/src/change_detection.rs
+++ b/src/change_detection.rs
@@ -41,12 +41,12 @@ impl<T: ?Sized> DetectChangesMut for Mut<'_, T> {
 
     #[inline]
     fn set_changed(&mut self) {
-        self.ticks.added.set_changed(self.ticks.change_tick);
+        self.ticks.changed.set_changed(self.ticks.change_tick);
     }
 
     #[inline]
-    fn set_last_changed(&mut self, last_change_tick: u32) {
-        self.ticks.last_change_tick = last_change_tick;
+    fn set_last_changed(&mut self, change_tick: u32) {
+        self.ticks.changed.set_changed(change_tick);
     }
 
     #[inline]

--- a/src/change_detection.rs
+++ b/src/change_detection.rs
@@ -104,3 +104,34 @@ impl<T: ?Sized> AsMut<T> for Mut<'_, T> {
         self.deref_mut()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_changed() {
+        let mut x = 0;
+        let mut x = Mut {
+            value: &mut x,
+            ticks: Ticks {
+                added: &mut Tick::new(1),
+                changed: &mut Tick::new(1),
+                last_change_tick: 0,
+                change_tick: 2,
+            },
+        };
+
+        assert!(x.is_added());
+        assert!(x.is_changed());
+
+        x.ticks.last_change_tick = x.ticks.change_tick;
+        x.ticks.change_tick += 1;
+        assert!(!x.is_added());
+        assert!(!x.is_changed());
+
+        *x = 1;
+        assert!(!x.is_added());
+        assert!(x.is_changed());
+    }
+}


### PR DESCRIPTION
The crate currently uses a custom implementation of `Mut`. It had a mistaken implementation which caused it to incorrectly report change ticks.