### PR TITLE
Allow usage outside of the Bevy engine (ECS-only scenarios)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,9 @@ jobs:
           toolchain: stable
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
-      - name: Run tests
+      - name: Run tests with minimal features
         run: cargo test --no-default-features
+      - name: "Run tests with default features"
         run: cargo test
 
   clippy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: Run tests with minimal features
-        run: cargo test --no-default-features
+        run: cargo test --lib --no-default-features
       - name: "Run tests with default features"
         run: cargo test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: Run tests
+        run: cargo test --no-default-features
         run: cargo test
 
   clippy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["game-development"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["bevy"]
+default = ["bevy_app", "bevy_core"]
 
 [dependencies]
 bevy-trait-query-impl = { path = "proc-macro", version = "0.4.0-dev" }
@@ -22,31 +22,36 @@ tracing = "0.1"
 git = "https://github.com/bevyengine/bevy"
 rev = "060711669903306c59eaea427498948992f0e768"
 
-[dependencies.bevy]
+[dependencies.bevy_app]
 git = "https://github.com/bevyengine/bevy"
 rev = "060711669903306c59eaea427498948992f0e768"
-default-features = false
+optional = true
+
+[dependencies.bevy_core]
+git = "https://github.com/bevyengine/bevy"
+rev = "060711669903306c59eaea427498948992f0e768"
 optional = true
 
 [dev-dependencies]
 criterion = "0.5"
 
+[dev-dependencies.bevy]
+git = "https://github.com/bevyengine/bevy"
+rev = "060711669903306c59eaea427498948992f0e768"
+default-features = false
+
 [[bench]]
 name = "concrete"
 harness = false
-required-features = ["bevy"]
 
 [[bench]]
 name = "all"
 harness = false
-required-features = ["bevy"]
 
 [[bench]]
 name = "one"
 harness = false
-required-features = ["bevy"]
 
 [[bench]]
 name = "fragmented"
 harness = false
-required-features = ["bevy"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,15 +34,19 @@ criterion = "0.5"
 [[bench]]
 name = "concrete"
 harness = false
+required-features = ["bevy"]
 
 [[bench]]
 name = "all"
 harness = false
+required-features = ["bevy"]
 
 [[bench]]
 name = "one"
 harness = false
+required-features = ["bevy"]
 
 [[bench]]
 name = "fragmented"
 harness = false
+required-features = ["bevy"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,22 @@ categories = ["game-development"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["bevy"]
+
 [dependencies]
 bevy-trait-query-impl = { path = "proc-macro", version = "0.4.0-dev" }
+tracing = "0.1"
+
+[dependencies.bevy_ecs]
+git = "https://github.com/bevyengine/bevy"
+rev = "060711669903306c59eaea427498948992f0e768"
 
 [dependencies.bevy]
 git = "https://github.com/bevyengine/bevy"
 rev = "060711669903306c59eaea427498948992f0e768"
 default-features = false
+optional = true
 
 [dev-dependencies]
 criterion = "0.5"

--- a/benches/all.rs
+++ b/benches/all.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::all)]
 
-use bevy::prelude::*;
+use bevy_core::Name;
+use bevy_ecs::prelude::*;
 use bevy_trait_query::*;
 use criterion::*;
 use std::fmt::Display;
@@ -58,7 +59,7 @@ impl<'w> Benchmark<'w> {
         }
 
         let query = world.query();
-        Self(world, query, default())
+        Self(world, query, Default::default())
     }
     fn multiple() -> Self {
         let mut world = World::new();
@@ -75,7 +76,7 @@ impl<'w> Benchmark<'w> {
         }
 
         let query = world.query();
-        Self(world, query, default())
+        Self(world, query, Default::default())
     }
     // Queries with only one, and queries with multiple.
     pub fn distributed() -> Self {
@@ -99,7 +100,7 @@ impl<'w> Benchmark<'w> {
         }
 
         let query = world.query();
-        Self(world, query, default())
+        Self(world, query, Default::default())
     }
 
     pub fn run(&mut self) {

--- a/benches/concrete.rs
+++ b/benches/concrete.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::all)]
 
-use bevy::prelude::*;
+use bevy_core::Name;
+use bevy_ecs::prelude::*;
 use bevy_trait_query::*;
 use criterion::*;
 use std::fmt::Display;
@@ -52,7 +53,7 @@ impl<'w> Benchmark<'w> {
         }
 
         let query = world.query();
-        Self(world, query, default())
+        Self(world, query, Default::default())
     }
     fn multiple() -> Self {
         let mut world = World::new();
@@ -66,7 +67,7 @@ impl<'w> Benchmark<'w> {
         }
 
         let query = world.query();
-        Self(world, query, default())
+        Self(world, query, Default::default())
     }
 
     pub fn run(&mut self) {

--- a/benches/fragmented.rs
+++ b/benches/fragmented.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::all)]
 
-use bevy::prelude::*;
+use bevy_ecs::prelude::*;
 use bevy_trait_query::*;
 use criterion::*;
 use std::fmt::Display;

--- a/benches/one.rs
+++ b/benches/one.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::all)]
 
-use bevy::prelude::*;
+use bevy_core::Name;
+use bevy_ecs::prelude::*;
 use bevy_trait_query::*;
 use criterion::*;
 use std::fmt::Display;
@@ -58,7 +59,7 @@ impl<'w> Benchmark<'w> {
         }
 
         let query = world.query();
-        Self(world, query, default())
+        Self(world, query, Default::default())
     }
     // There will be some entities that have multiple trait impls, and will be filtered out.
     pub fn filtered() -> Self {
@@ -82,7 +83,7 @@ impl<'w> Benchmark<'w> {
         }
 
         let query = world.query();
-        Self(world, query, default())
+        Self(world, query, Default::default())
     }
 
     pub fn run(&mut self) {

--- a/src/all.rs
+++ b/src/all.rs
@@ -1,12 +1,12 @@
-use bevy::ecs::{
+use bevy_ecs::{
     change_detection::{DetectChanges, Mut, Ref},
     component::{ComponentId, Tick},
     entity::Entity,
     query::{QueryItem, ReadOnlyWorldQuery, WorldQuery},
     storage::{SparseSets, Table, TableRow},
     world::{unsafe_world_cell::UnsafeWorldCell, World},
+    ptr::UnsafeCellDeref
 };
-use bevy::ptr::UnsafeCellDeref;
 
 use crate::{
     debug_unreachable, trait_registry_error, zip_exact, TraitImplMeta, TraitImplRegistry,
@@ -484,8 +484,8 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for All<&'a Trait> {
     unsafe fn set_archetype<'w>(
         fetch: &mut Self::Fetch<'w>,
         _state: &Self::State,
-        _archetype: &'w bevy::ecs::archetype::Archetype,
-        table: &'w bevy::ecs::storage::Table,
+        _archetype: &'w bevy_ecs::archetype::Archetype,
+        table: &'w bevy_ecs::storage::Table,
     ) {
         fetch.table = Some(table);
     }
@@ -493,7 +493,7 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for All<&'a Trait> {
     unsafe fn set_table<'w>(
         fetch: &mut Self::Fetch<'w>,
         _state: &Self::State,
-        table: &'w bevy::ecs::storage::Table,
+        table: &'w bevy_ecs::storage::Table,
     ) {
         fetch.table = Some(table);
     }
@@ -519,7 +519,7 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for All<&'a Trait> {
     #[inline]
     fn update_component_access(
         state: &Self::State,
-        access: &mut bevy::ecs::query::FilteredAccess<ComponentId>,
+        access: &mut bevy_ecs::query::FilteredAccess<ComponentId>,
     ) {
         for &component in &*state.components {
             assert!(
@@ -534,8 +534,8 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for All<&'a Trait> {
     #[inline]
     fn update_archetype_component_access(
         state: &Self::State,
-        archetype: &bevy::ecs::archetype::Archetype,
-        access: &mut bevy::ecs::query::Access<bevy::ecs::archetype::ArchetypeComponentId>,
+        archetype: &bevy_ecs::archetype::Archetype,
+        access: &mut bevy_ecs::query::Access<bevy_ecs::archetype::ArchetypeComponentId>,
     ) {
         for &component in &*state.components {
             if let Some(archetype_component_id) = archetype.get_archetype_component_id(component) {
@@ -596,8 +596,8 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for All<&'a mut Trait> {
     unsafe fn set_archetype<'w>(
         fetch: &mut Self::Fetch<'w>,
         _state: &Self::State,
-        _archetype: &'w bevy::ecs::archetype::Archetype,
-        table: &'w bevy::ecs::storage::Table,
+        _archetype: &'w bevy_ecs::archetype::Archetype,
+        table: &'w bevy_ecs::storage::Table,
     ) {
         fetch.table = Some(table);
     }
@@ -606,7 +606,7 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for All<&'a mut Trait> {
     unsafe fn set_table<'w>(
         fetch: &mut Self::Fetch<'w>,
         _state: &Self::State,
-        table: &'w bevy::ecs::storage::Table,
+        table: &'w bevy_ecs::storage::Table,
     ) {
         fetch.table = Some(table);
     }
@@ -632,7 +632,7 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for All<&'a mut Trait> {
     #[inline]
     fn update_component_access(
         state: &Self::State,
-        access: &mut bevy::ecs::query::FilteredAccess<ComponentId>,
+        access: &mut bevy_ecs::query::FilteredAccess<ComponentId>,
     ) {
         for &component in &*state.components {
             assert!(
@@ -647,8 +647,8 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for All<&'a mut Trait> {
     #[inline]
     fn update_archetype_component_access(
         state: &Self::State,
-        archetype: &bevy::ecs::archetype::Archetype,
-        access: &mut bevy::ecs::query::Access<bevy::ecs::archetype::ArchetypeComponentId>,
+        archetype: &bevy_ecs::archetype::Archetype,
+        access: &mut bevy_ecs::query::Access<bevy_ecs::archetype::ArchetypeComponentId>,
     ) {
         for &component in &*state.components {
             if let Some(archetype_component_id) = archetype.get_archetype_component_id(component) {

--- a/src/all.rs
+++ b/src/all.rs
@@ -2,10 +2,10 @@ use bevy_ecs::{
     change_detection::{DetectChanges, Mut, Ref},
     component::{ComponentId, Tick},
     entity::Entity,
+    ptr::UnsafeCellDeref,
     query::{QueryItem, ReadOnlyWorldQuery, WorldQuery},
     storage::{SparseSets, Table, TableRow},
     world::{unsafe_world_cell::UnsafeWorldCell, World},
-    ptr::UnsafeCellDeref
 };
 
 use crate::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,11 +253,9 @@
 //!
 
 use bevy_ecs::{
-    component::{ComponentId, StorageType, ComponentStorage},
+    component::{ComponentId, ComponentStorage, StorageType},
+    prelude::{Component, Resource, World},
     ptr::{Ptr, PtrMut},
-    prelude::{
-        Component, Resource, World
-    }
 };
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,8 +313,8 @@ impl RegisterExt for World {
     }
 }
 
-#[cfg(feature = "bevy")]
-impl RegisterExt for bevy::app::App {
+#[cfg(feature = "bevy_app")]
+impl RegisterExt for bevy_app::App {
     fn register_component_as<Trait: ?Sized + TraitQuery, C: Component>(&mut self) -> &mut Self
     where
         (C,): TraitQueryMarker<Trait, Covered = C>,

--- a/src/one.rs
+++ b/src/one.rs
@@ -1,6 +1,6 @@
 use std::{cell::UnsafeCell, marker::PhantomData};
 
-use bevy::ecs::{
+use bevy_ecs::{
     archetype::{Archetype, ArchetypeComponentId},
     change_detection::{Mut, Ref},
     component::{ComponentId, Tick},
@@ -8,8 +8,8 @@ use bevy::ecs::{
     query::{Access, FilteredAccess, QueryItem, ReadOnlyWorldQuery, WorldQuery},
     storage::{ComponentSparseSet, SparseSets, Table, TableRow},
     world::{unsafe_world_cell::UnsafeWorldCell, World},
+    ptr::{Ptr, ThinSlicePtr, UnsafeCellDeref}
 };
-use bevy::ptr::{Ptr, ThinSlicePtr, UnsafeCellDeref};
 
 use crate::{debug_unreachable, zip_exact, TraitImplMeta, TraitQuery, TraitQueryState};
 
@@ -101,8 +101,8 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for One<&'a Trait> {
     unsafe fn set_archetype<'w>(
         fetch: &mut OneTraitFetch<'w, Trait>,
         state: &Self::State,
-        _archetype: &'w bevy::ecs::archetype::Archetype,
-        table: &'w bevy::ecs::storage::Table,
+        _archetype: &'w bevy_ecs::archetype::Archetype,
+        table: &'w bevy_ecs::storage::Table,
     ) {
         // Search for a registered trait impl that is present in the archetype.
         // We check the table components first since it is faster to retrieve data of this type.
@@ -134,7 +134,7 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for One<&'a Trait> {
     unsafe fn set_table<'w>(
         fetch: &mut OneTraitFetch<'w, Trait>,
         state: &Self::State,
-        table: &'w bevy::ecs::storage::Table,
+        table: &'w bevy_ecs::storage::Table,
     ) {
         // Search for a registered trait impl that is present in the table.
         for (&component, &meta) in std::iter::zip(&*state.components, &*state.meta) {
@@ -206,7 +206,7 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for One<&'a Trait> {
     #[inline]
     fn update_component_access(
         state: &Self::State,
-        access: &mut bevy::ecs::query::FilteredAccess<ComponentId>,
+        access: &mut bevy_ecs::query::FilteredAccess<ComponentId>,
     ) {
         for &component in &*state.components {
             assert!(
@@ -221,8 +221,8 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for One<&'a Trait> {
     #[inline]
     fn update_archetype_component_access(
         state: &Self::State,
-        archetype: &bevy::ecs::archetype::Archetype,
-        access: &mut bevy::ecs::query::Access<bevy::ecs::archetype::ArchetypeComponentId>,
+        archetype: &bevy_ecs::archetype::Archetype,
+        access: &mut bevy_ecs::query::Access<bevy_ecs::archetype::ArchetypeComponentId>,
     ) {
         for &component in &*state.components {
             if let Some(archetype_component_id) = archetype.get_archetype_component_id(component) {
@@ -280,8 +280,8 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for One<&'a mut Trait> {
     unsafe fn set_archetype<'w>(
         fetch: &mut OneTraitFetch<'w, Trait>,
         state: &Self::State,
-        _archetype: &'w bevy::ecs::archetype::Archetype,
-        table: &'w bevy::ecs::storage::Table,
+        _archetype: &'w bevy_ecs::archetype::Archetype,
+        table: &'w bevy_ecs::storage::Table,
     ) {
         // Search for a registered trait impl that is present in the archetype.
         for (&component, &meta) in zip_exact(&*state.components, &*state.meta) {
@@ -312,7 +312,7 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for One<&'a mut Trait> {
     unsafe fn set_table<'w>(
         fetch: &mut OneTraitFetch<'w, Trait>,
         state: &Self::State,
-        table: &'w bevy::ecs::storage::Table,
+        table: &'w bevy_ecs::storage::Table,
     ) {
         // Search for a registered trait impl that is present in the table.
         for (&component, &meta) in std::iter::zip(&*state.components, &*state.meta) {
@@ -391,7 +391,7 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for One<&'a mut Trait> {
     #[inline]
     fn update_component_access(
         state: &Self::State,
-        access: &mut bevy::ecs::query::FilteredAccess<ComponentId>,
+        access: &mut bevy_ecs::query::FilteredAccess<ComponentId>,
     ) {
         for &component in &*state.components {
             assert!(
@@ -406,8 +406,8 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for One<&'a mut Trait> {
     #[inline]
     fn update_archetype_component_access(
         state: &Self::State,
-        archetype: &bevy::ecs::archetype::Archetype,
-        access: &mut bevy::ecs::query::Access<bevy::ecs::archetype::ArchetypeComponentId>,
+        archetype: &bevy_ecs::archetype::Archetype,
+        access: &mut bevy_ecs::query::Access<bevy_ecs::archetype::ArchetypeComponentId>,
     ) {
         for &component in &*state.components {
             if let Some(archetype_component_id) = archetype.get_archetype_component_id(component) {

--- a/src/one.rs
+++ b/src/one.rs
@@ -5,10 +5,10 @@ use bevy_ecs::{
     change_detection::{Mut, Ref},
     component::{ComponentId, Tick},
     entity::Entity,
+    ptr::{Ptr, ThinSlicePtr, UnsafeCellDeref},
     query::{Access, FilteredAccess, QueryItem, ReadOnlyWorldQuery, WorldQuery},
     storage::{ComponentSparseSet, SparseSets, Table, TableRow},
     world::{unsafe_world_cell::UnsafeWorldCell, World},
-    ptr::{Ptr, ThinSlicePtr, UnsafeCellDeref}
 };
 
 use crate::{debug_unreachable, zip_exact, TraitImplMeta, TraitQuery, TraitQueryState};

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,5 @@
-use bevy_ecs::prelude::*;
 use super::*;
+use bevy_ecs::prelude::*;
 use std::fmt::{Debug, Display};
 
 // Required for proc macros.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,3 +1,4 @@
+use bevy_ecs::prelude::*;
 use super::*;
 use std::fmt::{Debug, Display};
 
@@ -89,7 +90,7 @@ fn print_info(people: Query<One<&dyn Person>>, mut output: ResMut<Output>) {
             .0
             .push(format!("{}: {}", person.name(), person.age()));
     }
-    output.0.push(default());
+    output.0.push(Default::default());
 }
 
 fn age_up(mut people: Query<One<&mut dyn Person>>) {
@@ -163,7 +164,7 @@ fn print_all_info(people: Query<&dyn Person>, mut output: ResMut<Output>) {
                 .push(format!("{}: {}", person.name(), person.age()));
         }
     }
-    output.0.push(default());
+    output.0.push(Default::default());
 }
 
 fn age_up_fem(mut q: Query<&mut dyn Person, With<Fem>>) {
@@ -233,7 +234,7 @@ fn print_added_all_info(people: Query<All<&dyn Person>>, mut output: ResMut<Outp
             .0
             .push(format!("{}: {}", person.name(), person.age()));
     }
-    output.0.push(default());
+    output.0.push(Default::default());
 }
 
 #[test]
@@ -288,7 +289,7 @@ fn print_changed_all_info(people: Query<All<&dyn Person>>, mut output: ResMut<Ou
             .0
             .push(format!("{}: {}", person.name(), person.age()));
     }
-    output.0.push(default());
+    output.0.push(Default::default());
 }
 
 #[test]
@@ -338,7 +339,7 @@ fn print_added_one_info(
             .0
             .push(format!("{}: {}", person.name(), person.age()));
     }
-    output.0.push(default());
+    output.0.push(Default::default());
 }
 
 #[test]
@@ -389,7 +390,7 @@ fn print_changed_one_info(
             .0
             .push(format!("{}: {}", person.name(), person.age()));
     }
-    output.0.push(default());
+    output.0.push(Default::default());
 }
 
 #[test]
@@ -439,7 +440,7 @@ fn print_one_added_filter_info(
             .0
             .push(format!("{}: {}", person.name(), person.age()));
     }
-    output.0.push(default());
+    output.0.push(Default::default());
 }
 
 #[test]
@@ -490,7 +491,7 @@ fn print_one_changed_filter_info(
             .0
             .push(format!("{}: {}", person.name(), person.age()));
     }
-    output.0.push(default());
+    output.0.push(Default::default());
 }
 
 #[queryable]


### PR DESCRIPTION
This should allow for people who wish to use `bevy_ecs` outside of the Bevy ecosystem to take advantage of this crate without pulling in dependencies that aren't necessary for their projects. 

The `bevy` feature is active by default so current users should be unaffected when upgrading, using this in an ECS-only scenario simply requires disabling default features.

```toml
[dependencies.bevy-trait-query]
default-features = false
```

Great crate by the way, has been extremely useful for a hobby project of mine so far!👍