### PR TITLE
Bevy 0.13 Update PR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy-trait-query"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 
 description = "Implementation of trait queries for the bevy game engine"
@@ -19,21 +19,21 @@ bevy-trait-query-impl = { path = "proc-macro", version = "0.4.0" }
 tracing = "0.1"
 
 [dependencies.bevy_ecs]
-version = "0.12"
+version = "0.13"
 
 [dependencies.bevy_app]
-version = "0.12"
+version = "0.13"
 optional = true
 
 [dependencies.bevy_core]
-version = "0.12"
+version = "0.13"
 optional = true
 
 [dev-dependencies]
 criterion = "0.5"
 
 [dev-dependencies.bevy]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [[bench]]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Before using this crate, you should be familiar with bevy: https://bevyengine.or
 
 | Bevy Version | [Crate Version](CHANGELOG.md) |
 |--------------|---------------|
+| 0.13         | 0.5           |
 | 0.12         | 0.4           |
 | 0.11         | 0.3           |
 | 0.10         | 0.2           |

--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -148,7 +148,10 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
     let impl_generics_with_lifetime = quote! { <#( #impl_generics_with_lifetime ,)*> };
 
     let trait_object_query_code = quote! {
-        unsafe impl #impl_generics #imports::ReadOnlyWorldQuery for &#trait_object
+        unsafe impl #impl_generics #imports::QueryData for &#trait_object
+        #where_clause
+        { type ReadOnly = Self; }
+        unsafe impl #impl_generics #imports::ReadOnlyQueryData for &#trait_object
         #where_clause
         {}
 
@@ -157,7 +160,6 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
         {
             type Item<'__w> = #my_crate::ReadTraits<'__w, #trait_object>;
             type Fetch<'__w> = <#my_crate::All<&'__a #trait_object> as #imports::WorldQuery>::Fetch<'__w>;
-            type ReadOnly = Self;
             type State = #my_crate::TraitQueryState<#trait_object>;
 
             #[inline]
@@ -183,8 +185,8 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
             }
 
             const IS_DENSE: bool = <#my_crate::All<&#trait_object> as #imports::WorldQuery>::IS_DENSE;
-            const IS_ARCHETYPAL: bool =
-                <#my_crate::All<&#trait_object> as #imports::WorldQuery>::IS_ARCHETYPAL;
+            // const IS_ARCHETYPAL: bool =
+            //     <#my_crate::All<&#trait_object> as #imports::WorldQuery>::IS_ARCHETYPAL;
 
             #[inline]
             unsafe fn set_archetype<'w>(
@@ -230,18 +232,23 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
                 );
             }
 
-            #[inline]
-            fn update_archetype_component_access(
-                state: &Self::State,
-                archetype: &#imports::Archetype,
-                access: &mut #imports::Access<#imports::ArchetypeComponentId>,
-            ) {
-                <#my_crate::All<&#trait_object> as #imports::WorldQuery>::update_archetype_component_access(state, archetype, access);
-            }
+            // #[inline]
+            // fn update_archetype_component_access(
+            //     state: &Self::State,
+            //     archetype: &#imports::Archetype,
+            //     access: &mut #imports::Access<#imports::ArchetypeComponentId>,
+            // ) {
+            //     <#my_crate::All<&#trait_object> as #imports::WorldQuery>::update_archetype_component_access(state, archetype, access);
+            // }
 
             #[inline]
             fn init_state(world: &mut #imports::World) -> Self::State {
                 <#my_crate::All<&#trait_object> as #imports::WorldQuery>::init_state(world)
+            }
+
+            #[inline]
+            fn get_state(world: &#imports::World) -> Option<Self::State> {
+                <#my_crate::All<&#trait_object> as #imports::WorldQuery>::get_state(world)
             }
 
             #[inline]
@@ -253,12 +260,18 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
             }
         }
 
+        unsafe impl #impl_generics #imports::QueryData for &mut #trait_object
+        #where_clause
+        { type ReadOnly = Self; }
+        unsafe impl #impl_generics #imports::ReadOnlyQueryData for &mut #trait_object
+        #where_clause
+        {}
+
         unsafe impl #impl_generics_with_lifetime #imports::WorldQuery for &'__a mut #trait_object
         #where_clause
         {
             type Item<'__w> = #my_crate::WriteTraits<'__w, #trait_object>;
             type Fetch<'__w> = <#my_crate::All<&'__a #trait_object> as #imports::WorldQuery>::Fetch<'__w>;
-            type ReadOnly = &'__a #trait_object;
             type State = #my_crate::TraitQueryState<#trait_object>;
 
             #[inline]
@@ -284,8 +297,8 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
             }
 
             const IS_DENSE: bool = <#my_crate::All<&mut #trait_object> as #imports::WorldQuery>::IS_DENSE;
-            const IS_ARCHETYPAL: bool =
-                <#my_crate::All<&mut #trait_object> as #imports::WorldQuery>::IS_ARCHETYPAL;
+            // const IS_ARCHETYPAL: bool =
+            //     <#my_crate::All<&mut #trait_object> as #imports::WorldQuery>::IS_ARCHETYPAL;
 
             #[inline]
             unsafe fn set_archetype<'w>(
@@ -331,19 +344,24 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
                 );
             }
 
-            #[inline]
-            fn update_archetype_component_access(
-                state: &Self::State,
-                archetype: &#imports::Archetype,
-                access: &mut #imports::Access<#imports::ArchetypeComponentId>,
-            ) {
-                <#my_crate::All<&mut #trait_object> as #imports::WorldQuery>::update_archetype_component_access(state, archetype, access);
-            }
+            // #[inline]
+            // fn update_archetype_component_access(
+            //     state: &Self::State,
+            //     archetype: &#imports::Archetype,
+            //     access: &mut #imports::Access<#imports::ArchetypeComponentId>,
+            // ) {
+            //     <#my_crate::All<&mut #trait_object> as #imports::WorldQuery>::update_archetype_component_access(state, archetype, access);
+            // }
 
 
             #[inline]
             fn init_state(world: &mut #imports::World) -> Self::State {
                 <#my_crate::All<&mut #trait_object> as #imports::WorldQuery>::init_state(world)
+            }
+
+            #[inline]
+            fn get_state(world: &#imports::World) -> Option<Self::State> {
+                <#my_crate::All<&mut #trait_object> as #imports::WorldQuery>::get_state(world)
             }
 
             #[inline]

--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -254,11 +254,8 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
         unsafe impl #impl_generics_with_lifetime #imports::QueryData for &'__a mut #trait_object
         #where_clause
         {
-            type ReadOnly = &'__a mut #trait_object;
+            type ReadOnly = &'__a #trait_object;
         }
-        unsafe impl #impl_generics #imports::ReadOnlyQueryData for &mut #trait_object
-        #where_clause
-        {}
 
         unsafe impl #impl_generics_with_lifetime #imports::WorldQuery for &'__a mut #trait_object
         #where_clause

--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -150,7 +150,9 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
     let trait_object_query_code = quote! {
         unsafe impl #impl_generics #imports::QueryData for &#trait_object
         #where_clause
-        { type ReadOnly = Self; }
+        {
+            type ReadOnly = &'__a #trait_object;
+        }
         unsafe impl #impl_generics #imports::ReadOnlyQueryData for &#trait_object
         #where_clause
         {}

--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -251,10 +251,10 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
             }
         }
 
-        unsafe impl #impl_generics #imports::QueryData for &mut #trait_object
+        unsafe impl #impl_generics_with_lifetime #imports::QueryData for &'__a mut #trait_object
         #where_clause
         {
-            type ReadOnly = &'__a #trait_object;
+            type ReadOnly = &'__a mut #trait_object;
         }
         unsafe impl #impl_generics #imports::ReadOnlyQueryData for &mut #trait_object
         #where_clause

--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -185,8 +185,6 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
             }
 
             const IS_DENSE: bool = <#my_crate::All<&#trait_object> as #imports::WorldQuery>::IS_DENSE;
-            // const IS_ARCHETYPAL: bool =
-            //     <#my_crate::All<&#trait_object> as #imports::WorldQuery>::IS_ARCHETYPAL;
 
             #[inline]
             unsafe fn set_archetype<'w>(
@@ -231,15 +229,6 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
                     state, access,
                 );
             }
-
-            // #[inline]
-            // fn update_archetype_component_access(
-            //     state: &Self::State,
-            //     archetype: &#imports::Archetype,
-            //     access: &mut #imports::Access<#imports::ArchetypeComponentId>,
-            // ) {
-            //     <#my_crate::All<&#trait_object> as #imports::WorldQuery>::update_archetype_component_access(state, archetype, access);
-            // }
 
             #[inline]
             fn init_state(world: &mut #imports::World) -> Self::State {
@@ -297,8 +286,6 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
             }
 
             const IS_DENSE: bool = <#my_crate::All<&mut #trait_object> as #imports::WorldQuery>::IS_DENSE;
-            // const IS_ARCHETYPAL: bool =
-            //     <#my_crate::All<&mut #trait_object> as #imports::WorldQuery>::IS_ARCHETYPAL;
 
             #[inline]
             unsafe fn set_archetype<'w>(
@@ -343,16 +330,6 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
                     state, access,
                 );
             }
-
-            // #[inline]
-            // fn update_archetype_component_access(
-            //     state: &Self::State,
-            //     archetype: &#imports::Archetype,
-            //     access: &mut #imports::Access<#imports::ArchetypeComponentId>,
-            // ) {
-            //     <#my_crate::All<&mut #trait_object> as #imports::WorldQuery>::update_archetype_component_access(state, archetype, access);
-            // }
-
 
             #[inline]
             fn init_state(world: &mut #imports::World) -> Self::State {

--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -151,7 +151,7 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
         unsafe impl #impl_generics #imports::QueryData for &#trait_object
         #where_clause
         {
-            type ReadOnly = &'__a #trait_object;
+            type ReadOnly = Self;
         }
         unsafe impl #impl_generics #imports::ReadOnlyQueryData for &#trait_object
         #where_clause
@@ -253,7 +253,9 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
 
         unsafe impl #impl_generics #imports::QueryData for &mut #trait_object
         #where_clause
-        { type ReadOnly = Self; }
+        {
+            type ReadOnly = &'__a #trait_object;
+        }
         unsafe impl #impl_generics #imports::ReadOnlyQueryData for &mut #trait_object
         #where_clause
         {}

--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -364,14 +364,3 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
         #trait_object_query_code
     })
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}

--- a/src/all.rs
+++ b/src/all.rs
@@ -544,19 +544,6 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for All<&'a Trait> {
         *access = new_access;
     }
 
-    // #[inline]
-    // fn update_archetype_component_access(
-    //     state: &Self::State,
-    //     archetype: &bevy_ecs::archetype::Archetype,
-    //     access: &mut bevy_ecs::query::Access<bevy_ecs::archetype::ArchetypeComponentId>,
-    // ) {
-    //     for &component in &*state.components {
-    //         if let Some(archetype_component_id) = archetype.get_archetype_component_id(component) {
-    //             access.add_read(archetype_component_id);
-    //         }
-    //     }
-    // }
-
     #[inline]
     fn init_state(world: &mut World) -> Self::State {
         TraitQueryState::init(world)

--- a/src/all.rs
+++ b/src/all.rs
@@ -563,13 +563,16 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for All<&'a Trait> {
     }
 }
 
+unsafe impl<'a, Trait: ?Sized + TraitQuery> QueryData for All<&'a mut Trait> {
+    type ReadOnly = All<&'a Trait>;
+}
+
 // SAFETY: We only access the components registered in the trait registry.
 // This is known to match the set of components in the TraitQueryState,
 // which is used to match archetypes and register world access.
 unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for All<&'a mut Trait> {
     type Item<'w> = WriteTraits<'w, Trait>;
     type Fetch<'w> = AllTraitsFetch<'w, Trait>;
-    // type ReadOnly = All<&'a Trait>;
     type State = TraitQueryState<Trait>;
 
     #[inline]

--- a/src/all.rs
+++ b/src/all.rs
@@ -536,7 +536,8 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for All<&'a Trait> {
                 new_access.append_or(&intermediate);
                 new_access.extend_access(&intermediate);
             } else {
-                new_access.add_read(component);
+                new_access.and_with(component);
+                new_access.access_mut().add_read(component);
                 not_first = true;
             }
         }
@@ -655,7 +656,8 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for All<&'a mut Trait> {
                 new_access.append_or(&intermediate);
                 new_access.extend_access(&intermediate);
             } else {
-                new_access.add_write(component);
+                new_access.and_with(component);
+                new_access.access_mut().add_write(component);
                 not_first = true;
             }
         }

--- a/src/all.rs
+++ b/src/all.rs
@@ -3,7 +3,7 @@ use bevy_ecs::{
     component::{ComponentId, Tick},
     entity::Entity,
     ptr::UnsafeCellDeref,
-    query::{QueryData, QueryFilter, QueryItem, ReadOnlyQueryData, WorldQuery},
+    query::{QueryData, QueryItem, ReadOnlyQueryData, WorldQuery},
     storage::{SparseSets, Table, TableRow},
     world::{unsafe_world_cell::UnsafeWorldCell, World},
 };

--- a/src/all.rs
+++ b/src/all.rs
@@ -480,7 +480,6 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for All<&'a Trait> {
     }
 
     const IS_DENSE: bool = false;
-    // const IS_ARCHETYPAL: bool = false;
 
     #[inline]
     unsafe fn set_archetype<'w>(
@@ -599,7 +598,6 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for All<&'a mut Trait> {
     }
 
     const IS_DENSE: bool = false;
-    // const IS_ARCHETYPAL: bool = false;
 
     #[inline]
     unsafe fn set_archetype<'w>(

--- a/src/all.rs
+++ b/src/all.rs
@@ -3,7 +3,7 @@ use bevy_ecs::{
     component::{ComponentId, Tick},
     entity::Entity,
     ptr::UnsafeCellDeref,
-    query::{QueryData, QueryItem, ReadOnlyQueryData, WorldQuery},
+    query::{QueryData, QueryFilter, QueryItem, ReadOnlyQueryData, WorldQuery},
     storage::{SparseSets, Table, TableRow},
     world::{unsafe_world_cell::UnsafeWorldCell, World},
 };
@@ -447,6 +447,17 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> QueryData for All<&'a Trait> {
     type ReadOnly = Self;
 }
 unsafe impl<'a, Trait: ?Sized + TraitQuery> ReadOnlyQueryData for All<&'a Trait> {}
+impl<'a, Trait: ?Sized + TraitQuery> QueryFilter for All<&'a Trait> {
+    const IS_ARCHETYPAL: bool = false;
+    unsafe fn filter_fetch(
+        _fetch: &mut Self::Fetch<'_>,
+        _entity: Entity,
+        _table_row: TableRow,
+    ) -> bool {
+        // REVIEW: Is this ok?
+        true
+    }
+}
 
 // SAFETY: We only access the components registered in the trait registry.
 // This is known to match the set of components in the TraitQueryState,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,9 +405,7 @@ pub mod imports {
         component::Tick,
         component::{Component, ComponentId},
         entity::Entity,
-        query::{
-            Access, Added, Changed, FilteredAccess, QueryItem, ReadOnlyWorldQuery, WorldQuery,
-        },
+        query::{Access, Added, Changed, FilteredAccess, QueryItem, WorldQuery},
         storage::{Table, TableRow},
         world::{unsafe_world_cell::UnsafeWorldCell, World},
     };
@@ -436,6 +434,19 @@ impl<Trait: ?Sized + TraitQuery> TraitQueryState<Trait> {
             components: registry.components.clone().into_boxed_slice(),
             meta: registry.meta.clone().into_boxed_slice(),
         }
+    }
+
+    // REVIEW: inline?
+    // REVIEW: does it make sense to use the optional return type here? The call sites would be
+    // happy with this so I just made it use `Option`
+    fn get(world: &World) -> Option<Self> {
+        // REVIEW: is it ok to use the optional version here?
+        let registry = world.get_resource::<TraitImplRegistry<Trait>>()?;
+        // REVIEW: do we really need to clone here on get calls?
+        Some(Self {
+            components: registry.components.clone().into_boxed_slice(),
+            meta: registry.meta.clone().into_boxed_slice(),
+        })
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,7 +405,10 @@ pub mod imports {
         component::Tick,
         component::{Component, ComponentId},
         entity::Entity,
-        query::{Access, Added, Changed, FilteredAccess, QueryItem, WorldQuery},
+        query::{
+            Access, Added, Changed, FilteredAccess, QueryData, QueryFilter, QueryItem,
+            ReadOnlyQueryData, WorldQuery,
+        },
         storage::{Table, TableRow},
         world::{unsafe_world_cell::UnsafeWorldCell, World},
     };

--- a/src/one.rs
+++ b/src/one.rs
@@ -228,7 +228,8 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for One<&'a Trait> {
                 new_access.append_or(&intermediate);
                 new_access.extend_access(&intermediate);
             } else {
-                new_access.add_read(component);
+                new_access.and_with(component);
+                new_access.access_mut().add_read(component);
                 not_first = true;
             }
         }
@@ -414,7 +415,8 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for One<&'a mut Trait> {
                 new_access.append_or(&intermediate);
                 new_access.extend_access(&intermediate);
             } else {
-                new_access.add_write(component);
+                new_access.and_with(component);
+                new_access.access_mut().add_write(component);
                 not_first = true;
             }
         }
@@ -570,7 +572,8 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for OneAdded<Trait> {
                 new_access.append_or(&intermediate);
                 new_access.extend_access(&intermediate);
             } else {
-                new_access.add_read(component);
+                new_access.and_with(component);
+                new_access.access_mut().add_read(component);
                 not_first = true;
             }
         }
@@ -715,7 +718,8 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for OneChanged<Trait> {
                 new_access.append_or(&intermediate);
                 new_access.extend_access(&intermediate);
             } else {
-                new_access.add_read(component);
+                new_access.and_with(component);
+                new_access.access_mut().add_read(component);
                 not_first = true;
             }
         }

--- a/src/one.rs
+++ b/src/one.rs
@@ -797,12 +797,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for WithOne<Trait> {
     }
 
     #[inline]
-    unsafe fn set_table(
-        _fetch: &mut (),
-        _state: &Self::State,
-        _table: &bevy_ecs::storage::Table,
-    ) {
-    }
+    unsafe fn set_table(_fetch: &mut (), _state: &Self::State, _table: &bevy_ecs::storage::Table) {}
 
     #[inline]
     unsafe fn fetch<'w>(

--- a/src/one.rs
+++ b/src/one.rs
@@ -70,9 +70,8 @@ unsafe impl<'a, T: ?Sized + TraitQuery> QueryData for One<&'a T> {
 unsafe impl<'a, T: ?Sized + TraitQuery> ReadOnlyQueryData for One<&'a T> {}
 
 unsafe impl<'a, T: ?Sized + TraitQuery> QueryData for One<&'a mut T> {
-    type ReadOnly = Self;
+    type ReadOnly = One<&'a T>;
 }
-unsafe impl<'a, T: ?Sized + TraitQuery> ReadOnlyQueryData for One<&'a mut T> {}
 
 // SAFETY: We only access the components registered in TraitQueryState.
 // This same set of components is used to match archetypes, and used to register world access.

--- a/src/one.rs
+++ b/src/one.rs
@@ -214,28 +214,26 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for One<&'a Trait> {
         state: &Self::State,
         access: &mut bevy_ecs::query::FilteredAccess<ComponentId>,
     ) {
+        let mut new_access = access.clone();
+        let mut not_first = false;
         for &component in &*state.components {
             assert!(
                 !access.access().has_write(component),
                 "&{} conflicts with a previous access in this query. Shared access cannot coincide with exclusive access.",
                 std::any::type_name::<Trait>(),
             );
-            access.add_read(component);
+            if not_first {
+                let mut intermediate = access.clone();
+                intermediate.add_read(component);
+                new_access.append_or(&intermediate);
+                new_access.extend_access(&intermediate);
+            } else {
+                new_access.add_read(component);
+                not_first = true;
+            }
         }
+        *access = new_access;
     }
-
-    // #[inline]
-    // fn update_archetype_component_access(
-    //     state: &Self::State,
-    //     archetype: &bevy_ecs::archetype::Archetype,
-    //     access: &mut bevy_ecs::query::Access<bevy_ecs::archetype::ArchetypeComponentId>,
-    // ) {
-    //     for &component in &*state.components {
-    //         if let Some(archetype_component_id) = archetype.get_archetype_component_id(component) {
-    //             access.add_read(archetype_component_id);
-    //         }
-    //     }
-    // }
 
     #[inline]
     fn init_state(world: &mut World) -> Self::State {
@@ -404,28 +402,26 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for One<&'a mut Trait> {
         state: &Self::State,
         access: &mut bevy_ecs::query::FilteredAccess<ComponentId>,
     ) {
+        let mut new_access = access.clone();
+        let mut not_first = false;
         for &component in &*state.components {
             assert!(
                 !access.access().has_write(component),
                 "&mut {} conflicts with a previous access in this query. Mutable component access must be unique.",
                 std::any::type_name::<Trait>(),
             );
-            access.add_write(component);
+            if not_first {
+                let mut intermediate = access.clone();
+                intermediate.add_write(component);
+                new_access.append_or(&intermediate);
+                new_access.extend_access(&intermediate);
+            } else {
+                new_access.add_write(component);
+                not_first = true;
+            }
         }
+        *access = new_access;
     }
-
-    // #[inline]
-    // fn update_archetype_component_access(
-    //     state: &Self::State,
-    //     archetype: &bevy_ecs::archetype::Archetype,
-    //     access: &mut bevy_ecs::query::Access<bevy_ecs::archetype::ArchetypeComponentId>,
-    // ) {
-    //     for &component in &*state.components {
-    //         if let Some(archetype_component_id) = archetype.get_archetype_component_id(component) {
-    //             access.add_write(archetype_component_id);
-    //         }
-    //     }
-    // }
 
     #[inline]
     fn init_state(world: &mut World) -> Self::State {
@@ -564,28 +560,26 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for OneAdded<Trait> {
 
     #[inline]
     fn update_component_access(state: &Self::State, access: &mut FilteredAccess<ComponentId>) {
+        let mut new_access = access.clone();
+        let mut not_first = false;
         for &component in &*state.components {
             assert!(
                 !access.access().has_write(component),
                 "&{} conflicts with a previous access in this query. Shared access cannot coincide with exclusive access.",
                 std::any::type_name::<Trait>(),
             );
-            access.add_read(component);
+            if not_first {
+                let mut intermediate = access.clone();
+                intermediate.add_read(component);
+                new_access.append_or(&intermediate);
+                new_access.extend_access(&intermediate);
+            } else {
+                new_access.add_read(component);
+                not_first = true;
+            }
         }
+        *access = new_access;
     }
-
-    // #[inline]
-    // fn update_archetype_component_access(
-    //     state: &Self::State,
-    //     archetype: &Archetype,
-    //     access: &mut Access<ArchetypeComponentId>,
-    // ) {
-    //     for &component in &*state.components {
-    //         if let Some(archetype_component_id) = archetype.get_archetype_component_id(component) {
-    //             access.add_read(archetype_component_id);
-    //         }
-    //     }
-    // }
 
     #[inline]
     fn init_state(world: &mut World) -> Self::State {
@@ -712,28 +706,26 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for OneChanged<Trait> {
 
     #[inline]
     fn update_component_access(state: &Self::State, access: &mut FilteredAccess<ComponentId>) {
+        let mut new_access = access.clone();
+        let mut not_first = false;
         for &component in &*state.components {
             assert!(
                 !access.access().has_write(component),
                 "&{} conflicts with a previous access in this query. Shared access cannot coincide with exclusive access.",
                 std::any::type_name::<Trait>(),
             );
-            access.add_read(component);
+            if not_first {
+                let mut intermediate = access.clone();
+                intermediate.add_read(component);
+                new_access.append_or(&intermediate);
+                new_access.extend_access(&intermediate);
+            } else {
+                new_access.add_read(component);
+                not_first = true;
+            }
         }
+        *access = new_access;
     }
-
-    // #[inline]
-    // fn update_archetype_component_access(
-    //     state: &Self::State,
-    //     archetype: &Archetype,
-    //     access: &mut Access<ArchetypeComponentId>,
-    // ) {
-    //     for &component in &*state.components {
-    //         if let Some(archetype_component_id) = archetype.get_archetype_component_id(component) {
-    //             access.add_read(archetype_component_id);
-    //         }
-    //     }
-    // }
 
     #[inline]
     fn init_state(world: &mut World) -> Self::State {

--- a/src/one.rs
+++ b/src/one.rs
@@ -776,8 +776,8 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for WithOne<Trait> {
     }
 
     #[inline]
-    unsafe fn init_fetch<'w>(
-        _world: UnsafeWorldCell<'w>,
+    unsafe fn init_fetch(
+        _world: UnsafeWorldCell<'_>,
         _state: &Self::State,
         _last_run: Tick,
         _this_run: Tick,
@@ -797,10 +797,10 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for WithOne<Trait> {
     }
 
     #[inline]
-    unsafe fn set_table<'w>(
+    unsafe fn set_table(
         _fetch: &mut (),
         _state: &Self::State,
-        _table: &'w bevy_ecs::storage::Table,
+        _table: &bevy_ecs::storage::Table,
     ) {
     }
 

--- a/src/one.rs
+++ b/src/one.rs
@@ -259,7 +259,6 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for One<&'a Trait> {
 unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for One<&'a mut Trait> {
     type Item<'w> = Mut<'w, Trait>;
     type Fetch<'w> = OneTraitFetch<'w, Trait>;
-    // type ReadOnly = One<&'a Trait>;
     type State = TraitQueryState<Trait>;
 
     #[inline]
@@ -476,7 +475,6 @@ pub struct ChangeDetectionFetch<'w> {
 unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for OneAdded<Trait> {
     type Item<'w> = bool;
     type Fetch<'w> = ChangeDetectionFetch<'w>;
-    // type ReadOnly = Self;
     type State = TraitQueryState<Trait>;
 
     fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {

--- a/src/one.rs
+++ b/src/one.rs
@@ -283,7 +283,6 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for One<&'a mut Trait> {
     }
 
     const IS_DENSE: bool = false;
-    // const IS_ARCHETYPAL: bool = false;
 
     #[inline]
     unsafe fn set_archetype<'w>(
@@ -501,7 +500,6 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for OneAdded<Trait> {
     // This will always be false for us, as we (so far) do not know at compile time whether the
     // components our trait has been impl'd for are stored in table or in sparse set
     const IS_DENSE: bool = false;
-    // const IS_ARCHETYPAL: bool = false;
 
     #[inline]
     unsafe fn set_archetype<'w>(
@@ -647,7 +645,6 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for OneChanged<Trait> {
     // This will always be false for us, as we (so far) do not know at compile time whether the
     // components our trait has been impl'd for are stored in table or in sparse set
     const IS_DENSE: bool = false;
-    // const IS_ARCHETYPAL: bool = false;
 
     #[inline]
     unsafe fn set_archetype<'w>(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -494,6 +494,49 @@ fn print_one_changed_filter_info(
     output.0.push(Default::default());
 }
 
+#[test]
+fn with_one_filter() {
+    let mut world = World::new();
+    world.init_resource::<Output>();
+    world
+        .register_component_as::<dyn Person, Human>()
+        .register_component_as::<dyn Person, Dolphin>();
+
+    world.spawn(Human("Henry".to_owned(), 22));
+    world.spawn((Human("Henry".to_owned(), 22), Dolphin(22)));
+    world.spawn(Dolphin(22));
+    world.spawn(Fem);
+
+    let mut schedule = Schedule::default();
+    schedule.add_systems(print_with_one_filter_info);
+
+    schedule.run(&mut world);
+
+    assert_eq!(
+        world.resource::<Output>().0,
+        &[
+            "People that are either Human or Dolphin but not both:",
+            "0v1",
+            "2v1",
+            "",
+        ]
+    );
+}
+
+// Prints the entity id of every `Person` with exactly one component implementing the trait
+fn print_with_one_filter_info(
+    people: Query<Entity, WithOne<dyn Person>>,
+    mut output: ResMut<Output>,
+) {
+    output
+        .0
+        .push("People that are either Human or Dolphin but not both:".to_string());
+    for person in (&people).into_iter() {
+        output.0.push(format!("{person:?}"));
+    }
+    output.0.push(Default::default());
+}
+
 #[queryable]
 pub trait Messages {
     fn send(&mut self, _: &dyn Display);


### PR DESCRIPTION
## Ready for review ✅ 

The PR is in a review-ready state now. All tests are green and we get now compile errors.

---

<details>

<summary> Irrelevant and superseded by the section above now, just leaving this first version of the description for transparency </summary>


This is most probably a very naive try to update this crate to bevy 0.13. The main things that I changed were:

- bump versions
- split the `ReadOnlyWorldQuery` impl into `QueryData` + `ReadOnlyQueryData` impls
- add `QueryFilter` impls for `OneAdded` and `OneChanged`
- add the missing `get_state` method on the `WorldQuery` impl
- the `get_state` change includes adding a new `get` method for `TraitQueryState` which mostly follows the `init` method
- adjusting the proc macros to reflect these changes

Most of these adjustments are super naive. I tried to mirror existing code as closely as possible (e.g. I consulted the bevy main repo for the trait impls). Most notably:

- For starters: At least it compiles :D 
- The tests all still fail D:
- I didn't find any counter part for `update_archetype_component_access` in bevy 0.13

I'm happy to continue working on this update (and also future update) but I'm afraid I need a bit of mentoring as I'm stuck now

</details>

---

Related to #54 