### PR TITLE
Follow-up hotfix for #55

### DIFF
--- a/src/one.rs
+++ b/src/one.rs
@@ -776,8 +776,8 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for WithOne<Trait> {
     }
 
     #[inline]
-    unsafe fn init_fetch(
-        _world: UnsafeWorldCell<'_>,
+    unsafe fn init_fetch<'w>(
+        _world: UnsafeWorldCell<'w>,
         _state: &Self::State,
         _last_run: Tick,
         _this_run: Tick,
@@ -797,7 +797,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for WithOne<Trait> {
     }
 
     #[inline]
-    unsafe fn set_table(_fetch: &mut (), _state: &Self::State, _table: &bevy_ecs::storage::Table) {}
+    unsafe fn set_table<'w>(_fetch: &mut (), _state: &Self::State, _table: &'w bevy_ecs::storage::Table) {}
 
     #[inline]
     unsafe fn fetch<'w>(


### PR DESCRIPTION
After updating to version `0.5` I am getting the following error:

```
error[E0576]: cannot find method or associated constant `update_archetype_component_access` in trait `bevy_trait_quer
y::imports::WorldQuery
```

above all usages of the `queryable` proc macro.

Disclaimer: I'm still trying to figure out why this should work in the first place.