### PR TITLE
Bevy 0.14 update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,21 +19,21 @@ bevy-trait-query-impl = { path = "proc-macro", version = "0.5.0" }
 tracing = "0.1"
 
 [dependencies.bevy_ecs]
-version = "0.14.0"
+version = "0.14"
 
 [dependencies.bevy_app]
-version = "0.14.0"
+version = "0.14"
 optional = true
 
 [dependencies.bevy_core]
-version = "0.14.0"
+version = "0.14"
 optional = true
 
 [dev-dependencies]
 criterion = "0.5"
 
 [dev-dependencies.bevy]
-version = "0.14.0"
+version = "0.14"
 default-features = false
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,21 +19,21 @@ bevy-trait-query-impl = { path = "proc-macro", version = "0.5.0" }
 tracing = "0.1"
 
 [dependencies.bevy_ecs]
-version = "0.13"
+version = "0.14.0-rc.3"
 
 [dependencies.bevy_app]
-version = "0.13"
+version = "0.14.0-rc.3"
 optional = true
 
 [dependencies.bevy_core]
-version = "0.13"
+version = "0.14.0-rc.3"
 optional = true
 
 [dev-dependencies]
 criterion = "0.5"
 
 [dev-dependencies.bevy]
-version = "0.13"
+version = "0.14.0-rc.3"
 default-features = false
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,21 +19,21 @@ bevy-trait-query-impl = { path = "proc-macro", version = "0.5.0" }
 tracing = "0.1"
 
 [dependencies.bevy_ecs]
-version = "0.14.0-rc.3"
+version = "0.14.0"
 
 [dependencies.bevy_app]
-version = "0.14.0-rc.3"
+version = "0.14.0"
 optional = true
 
 [dependencies.bevy_core]
-version = "0.14.0-rc.3"
+version = "0.14.0"
 optional = true
 
 [dev-dependencies]
 criterion = "0.5"
 
 [dev-dependencies.bevy]
-version = "0.14.0-rc.3"
+version = "0.14.0"
 default-features = false
 
 [[bench]]

--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -238,8 +238,9 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
             }
 
             #[inline]
-            fn get_state(world: &#imports::World) -> Option<Self::State> {
-                <#my_crate::All<&#trait_object> as #imports::WorldQuery>::get_state(world)
+            fn get_state(_: &#imports::Components) -> Option<Self::State> {
+                // TODO: fix this https://github.com/bevyengine/bevy/issues/13798
+                None
             }
 
             #[inline]
@@ -338,8 +339,9 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
             }
 
             #[inline]
-            fn get_state(world: &#imports::World) -> Option<Self::State> {
-                <#my_crate::All<&mut #trait_object> as #imports::WorldQuery>::get_state(world)
+            fn get_state(_: &#imports::Components) -> Option<Self::State> {
+                // TODO: fix this https://github.com/bevyengine/bevy/issues/13798
+                None
             }
 
             #[inline]

--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -240,7 +240,7 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
             #[inline]
             fn get_state(_: &#imports::Components) -> Option<Self::State> {
                 // TODO: fix this https://github.com/bevyengine/bevy/issues/13798
-                None
+                panic!("transmuting and any other operations concerning the state of a query are currently broken and shouldn't be used. See https://github.com/JoJoJet/bevy-trait-query/issues/59");
             }
 
             #[inline]
@@ -341,7 +341,7 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
             #[inline]
             fn get_state(_: &#imports::Components) -> Option<Self::State> {
                 // TODO: fix this https://github.com/bevyengine/bevy/issues/13798
-                None
+                panic!("transmuting and any other operations concerning the state of a query are currently broken and shouldn't be used. See https://github.com/JoJoJet/bevy-trait-query/issues/59");
             }
 
             #[inline]

--- a/src/all.rs
+++ b/src/all.rs
@@ -552,7 +552,7 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for All<&'a Trait> {
     #[inline]
     fn get_state(_: &Components) -> Option<Self::State> {
         // TODO: fix this https://github.com/bevyengine/bevy/issues/13798
-        None
+        panic!("transmuting and any other operations concerning the state of a query are currently broken and shouldn't be used. See https://github.com/JoJoJet/bevy-trait-query/issues/59");
     }
 
     #[inline]
@@ -673,7 +673,7 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for All<&'a mut Trait> {
     #[inline]
     fn get_state(_: &Components) -> Option<Self::State> {
         // TODO: fix this https://github.com/bevyengine/bevy/issues/13798
-        None
+        panic!("transmuting and any other operations concerning the state of a query are currently broken and shouldn't be used. See https://github.com/JoJoJet/bevy-trait-query/issues/59");
     }
 
     #[inline]

--- a/src/all.rs
+++ b/src/all.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::{
     change_detection::{DetectChanges, Mut, Ref},
-    component::{ComponentId, Tick},
+    component::{ComponentId, Components, Tick},
     entity::Entity,
     ptr::UnsafeCellDeref,
     query::{QueryData, QueryItem, ReadOnlyQueryData, WorldQuery},
@@ -550,8 +550,9 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for All<&'a Trait> {
     }
 
     #[inline]
-    fn get_state(world: &World) -> Option<Self::State> {
-        TraitQueryState::get(world)
+    fn get_state(_: &Components) -> Option<Self::State> {
+        // TODO: fix this https://github.com/bevyengine/bevy/issues/13798
+        None
     }
 
     #[inline]
@@ -670,8 +671,9 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for All<&'a mut Trait> {
     }
 
     #[inline]
-    fn get_state(world: &World) -> Option<Self::State> {
-        TraitQueryState::get(world)
+    fn get_state(_: &Components) -> Option<Self::State> {
+        // TODO: fix this https://github.com/bevyengine/bevy/issues/13798
+        None
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,18 +439,18 @@ impl<Trait: ?Sized + TraitQuery> TraitQueryState<Trait> {
         }
     }
 
-    // REVIEW: inline?
-    // REVIEW: does it make sense to use the optional return type here? The call sites would be
-    // happy with this so I just made it use `Option`
-    fn get(world: &World) -> Option<Self> {
-        // REVIEW: is it ok to use the optional version here?
-        let registry = world.get_resource::<TraitImplRegistry<Trait>>()?;
-        // REVIEW: do we really need to clone here on get calls?
-        Some(Self {
-            components: registry.components.clone().into_boxed_slice(),
-            meta: registry.meta.clone().into_boxed_slice(),
-        })
-    }
+    // // REVIEW: inline?
+    // // REVIEW: does it make sense to use the optional return type here? The call sites would be
+    // // happy with this so I just made it use `Option`
+    // fn get(world: &World) -> Option<Self> {
+    //     // REVIEW: is it ok to use the optional version here?
+    //     let registry = world.get_resource::<TraitImplRegistry<Trait>>()?;
+    //     // REVIEW: do we really need to clone here on get calls?
+    //     Some(Self {
+    //         components: registry.components.clone().into_boxed_slice(),
+    //         meta: registry.meta.clone().into_boxed_slice(),
+    //     })
+    // }
 
     #[inline]
     fn matches_component_set_any(&self, set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,7 +253,7 @@
 //!
 
 use bevy_ecs::{
-    component::{ComponentId, ComponentStorage, StorageType},
+    component::{ComponentId, StorageType},
     prelude::{Component, Resource, World},
     ptr::{Ptr, PtrMut},
 };
@@ -317,7 +317,7 @@ impl RegisterExt for bevy_app::App {
     where
         (C,): TraitQueryMarker<Trait, Covered = C>,
     {
-        self.world.register_component_as::<Trait, C>();
+        self.world_mut().register_component_as::<Trait, C>();
         self
     }
 }
@@ -368,7 +368,7 @@ impl<Trait: ?Sized + TraitQuery> TraitImplRegistry<Trait> {
         self.components.push(component);
         self.meta.push(meta);
 
-        match <C as Component>::Storage::STORAGE_TYPE {
+        match <C as Component>::STORAGE_TYPE {
             StorageType::Table => {
                 self.table_components.push(component);
                 self.table_meta.push(meta);
@@ -403,7 +403,7 @@ pub mod imports {
     pub use bevy_ecs::{
         archetype::{Archetype, ArchetypeComponentId},
         component::Tick,
-        component::{Component, ComponentId},
+        component::{Component, ComponentId, Components},
         entity::Entity,
         query::{
             Access, Added, Changed, FilteredAccess, QueryData, QueryFilter, QueryItem,

--- a/src/one.rs
+++ b/src/one.rs
@@ -3,7 +3,7 @@ use std::{cell::UnsafeCell, marker::PhantomData};
 use bevy_ecs::{
     archetype::Archetype,
     change_detection::{Mut, Ref},
-    component::{ComponentId, Tick},
+    component::{ComponentId, Components, Tick},
     entity::Entity,
     ptr::{Ptr, ThinSlicePtr, UnsafeCellDeref},
     query::{FilteredAccess, QueryData, QueryFilter, QueryItem, ReadOnlyQueryData, WorldQuery},
@@ -242,8 +242,9 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for One<&'a Trait> {
     }
 
     #[inline]
-    fn get_state(world: &World) -> Option<Self::State> {
-        TraitQueryState::get(world)
+    fn get_state(_: &Components) -> Option<Self::State> {
+        // TODO: fix this https://github.com/bevyengine/bevy/issues/13798
+        None
     }
 
     #[inline]
@@ -429,8 +430,9 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for One<&'a mut Trait> {
     }
 
     #[inline]
-    fn get_state(world: &World) -> Option<Self::State> {
-        TraitQueryState::get(world)
+    fn get_state(_: &Components) -> Option<Self::State> {
+        // TODO: fix this https://github.com/bevyengine/bevy/issues/13798
+        None
     }
 
     #[inline]
@@ -586,8 +588,9 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for OneAdded<Trait> {
     }
 
     #[inline]
-    fn get_state(world: &World) -> Option<Self::State> {
-        TraitQueryState::get(world)
+    fn get_state(_: &Components) -> Option<Self::State> {
+        // TODO: fix this https://github.com/bevyengine/bevy/issues/13798
+        None
     }
 
     fn matches_component_set(
@@ -732,8 +735,9 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for OneChanged<Trait> {
     }
 
     #[inline]
-    fn get_state(world: &World) -> Option<Self::State> {
-        TraitQueryState::get(world)
+    fn get_state(_: &Components) -> Option<Self::State> {
+        // TODO: fix this https://github.com/bevyengine/bevy/issues/13798
+        None
     }
 
     fn matches_component_set(
@@ -840,8 +844,9 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for WithOne<Trait> {
     }
 
     #[inline]
-    fn get_state(world: &World) -> Option<Self::State> {
-        TraitQueryState::get(world)
+    fn get_state(_: &Components) -> Option<Self::State> {
+        // TODO: fix this https://github.com/bevyengine/bevy/issues/13798
+        None
     }
 
     #[inline]

--- a/src/one.rs
+++ b/src/one.rs
@@ -244,7 +244,7 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for One<&'a Trait> {
     #[inline]
     fn get_state(_: &Components) -> Option<Self::State> {
         // TODO: fix this https://github.com/bevyengine/bevy/issues/13798
-        None
+        panic!("transmuting and any other operations concerning the state of a query are currently broken and shouldn't be used. See https://github.com/JoJoJet/bevy-trait-query/issues/59");
     }
 
     #[inline]
@@ -432,7 +432,7 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> WorldQuery for One<&'a mut Trait> {
     #[inline]
     fn get_state(_: &Components) -> Option<Self::State> {
         // TODO: fix this https://github.com/bevyengine/bevy/issues/13798
-        None
+        panic!("transmuting and any other operations concerning the state of a query are currently broken and shouldn't be used. See https://github.com/JoJoJet/bevy-trait-query/issues/59");
     }
 
     #[inline]
@@ -590,7 +590,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for OneAdded<Trait> {
     #[inline]
     fn get_state(_: &Components) -> Option<Self::State> {
         // TODO: fix this https://github.com/bevyengine/bevy/issues/13798
-        None
+        panic!("transmuting and any other operations concerning the state of a query are currently broken and shouldn't be used. See https://github.com/JoJoJet/bevy-trait-query/issues/59");
     }
 
     fn matches_component_set(
@@ -737,7 +737,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for OneChanged<Trait> {
     #[inline]
     fn get_state(_: &Components) -> Option<Self::State> {
         // TODO: fix this https://github.com/bevyengine/bevy/issues/13798
-        None
+        panic!("transmuting and any other operations concerning the state of a query are currently broken and shouldn't be used. See https://github.com/JoJoJet/bevy-trait-query/issues/59");
     }
 
     fn matches_component_set(
@@ -846,7 +846,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for WithOne<Trait> {
     #[inline]
     fn get_state(_: &Components) -> Option<Self::State> {
         // TODO: fix this https://github.com/bevyengine/bevy/issues/13798
-        None
+        panic!("transmuting and any other operations concerning the state of a query are currently broken and shouldn't be used. See https://github.com/JoJoJet/bevy-trait-query/issues/59");
     }
 
     #[inline]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -516,8 +516,8 @@ fn with_one_filter() {
         world.resource::<Output>().0,
         &[
             "People that are either Human or Dolphin but not both:",
-            "0v1|4294967296",
-            "2v1|4294967298",
+            "0v1",
+            "2v1",
             "",
         ]
     );

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -516,8 +516,8 @@ fn with_one_filter() {
         world.resource::<Output>().0,
         &[
             "People that are either Human or Dolphin but not both:",
-            "0v1",
-            "2v1",
+            "0v1|4294967296",
+            "2v1|4294967298",
             "",
         ]
     );
@@ -532,7 +532,7 @@ fn print_with_one_filter_info(
         .0
         .push("People that are either Human or Dolphin but not both:".to_string());
     for person in (&people).into_iter() {
-        output.0.push(format!("{person:?}"));
+        output.0.push(format!("{person}"));
     }
     output.0.push(Default::default());
 }


### PR DESCRIPTION
This kind of solves https://github.com/JoJoJet/bevy-trait-query/issues/59 I'm not sure if the added test actually tests the UB but it seems to pass on my machine without panics. I'll double check it though. Update: It looks like the panic is only hit if we transmute to something which includes one of the `bevy-trait-query` component types (`One` or `All`). I added an additional test which highlights this. There's also an explicit panic in `bevy-trait-query` now which will guide users to the issue which causes the trouble and which provides minimal help.

For performance differences, see this comment: https://github.com/JoJoJet/bevy-trait-query/issues/59#issuecomment-2212516814 (TLDR: `All` performance improves, `One` performance regresses)