### PR TITLE
Improve `cargo release` again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ bevy_app = "0.14"
 bevy_core = "0.14"
 
 # proc macro
+bevy-trait-query-impl = { version = "0.6.0", path = "./bevy-trait-query-impl" }
 proc-macro2 = "1"
 syn = { version = "2", features = ["full"] }
 quote = "1"

--- a/bevy-trait-query/Cargo.toml
+++ b/bevy-trait-query/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["game-development"]
 default = ["bevy_app", "bevy_core"]
 
 [dependencies]
-bevy-trait-query-impl = { version = "0.6.0" }
+bevy-trait-query-impl.workspace = true
 tracing.workspace = true
 bevy_ecs.workspace = true
 bevy_app = { workspace = true, optional = true}

--- a/release.toml
+++ b/release.toml
@@ -1,1 +1,0 @@
-tag-name = "{{prefix}}v{{version}}"


### PR DESCRIPTION
This finally gets rid of us having to do two separate releases. One `cargo release minor` will do now. I knew I set this up somewhere else before 😅 