### PR TITLE
Allow queries to work without mutable world access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,8 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bevy"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec689b5a79452b6f777b889bbff22d3216b82a8d2ab7814d4a0eb571e9938d97"
+version = "0.19.0-dev"
+source = "git+https://github.com/bevyengine/bevy.git?rev=refs%2Fpull%2F22670%2Fhead#18aadd9f69f483e7f28ae6d91766b66fef1ded7e"
 dependencies = [
  "bevy_internal",
 ]
@@ -159,18 +158,16 @@ dependencies = [
 
 [[package]]
 name = "bevy_android"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008133458cfe0d43a8870bfc4c5a729467cc5d9246611462add38bcf45ed896f"
+version = "0.19.0-dev"
+source = "git+https://github.com/bevyengine/bevy.git?rev=refs%2Fpull%2F22670%2Fhead#18aadd9f69f483e7f28ae6d91766b66fef1ded7e"
 dependencies = [
  "android-activity",
 ]
 
 [[package]]
 name = "bevy_app"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2271a0123a7cc355c3fe98754360c75aa84b29f2a6b1a9f8c00aac427570d174"
+version = "0.19.0-dev"
+source = "git+https://github.com/bevyengine/bevy.git?rev=refs%2Fpull%2F22670%2Fhead#18aadd9f69f483e7f28ae6d91766b66fef1ded7e"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -188,9 +185,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_derive"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b6a05c31f54c83d681f1b8699bbaf581f06b25a40c9a6bb815625f731f5ba9"
+version = "0.19.0-dev"
+source = "git+https://github.com/bevyengine/bevy.git?rev=refs%2Fpull%2F22670%2Fhead#18aadd9f69f483e7f28ae6d91766b66fef1ded7e"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -199,9 +195,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_diagnostic"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aca4caa8a9014a435dca382b1bdebaee4363e9be69882c598fc4ff4d7cd56e6a"
+version = "0.19.0-dev"
+source = "git+https://github.com/bevyengine/bevy.git?rev=refs%2Fpull%2F22670%2Fhead#18aadd9f69f483e7f28ae6d91766b66fef1ded7e"
 dependencies = [
  "atomic-waker",
  "bevy_app",
@@ -215,9 +210,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24637a7c8643cab493f4085cda6bde4895f0e0816699c59006f18819da2ca0b8"
+version = "0.19.0-dev"
+source = "git+https://github.com/bevyengine/bevy.git?rev=refs%2Fpull%2F22670%2Fhead#18aadd9f69f483e7f28ae6d91766b66fef1ded7e"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -243,9 +237,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs_macros"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eb14c18ca71e11c69fbae873c2db129064efac6d52e48d0127d37bfba1acfa8"
+version = "0.19.0-dev"
+source = "git+https://github.com/bevyengine/bevy.git?rev=refs%2Fpull%2F22670%2Fhead#18aadd9f69f483e7f28ae6d91766b66fef1ded7e"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -255,9 +248,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_input"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2853993baf27b963a417d3603a73e02e39c5041913cd1ba7211b0a3037b191"
+version = "0.19.0-dev"
+source = "git+https://github.com/bevyengine/bevy.git?rev=refs%2Fpull%2F22670%2Fhead#18aadd9f69f483e7f28ae6d91766b66fef1ded7e"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -271,9 +263,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_internal"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57463815630ea71221c0b8e7bff72d816a3071a89507c45f9e2686fbb5e1956b"
+version = "0.19.0-dev"
+source = "git+https://github.com/bevyengine/bevy.git?rev=refs%2Fpull%2F22670%2Fhead#18aadd9f69f483e7f28ae6d91766b66fef1ded7e"
 dependencies = [
  "bevy_android",
  "bevy_app",
@@ -293,21 +284,19 @@ dependencies = [
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7272fca0bf30d8ca2571a803598856104b63e5c596d52850f811ed37c5e1e3"
+version = "0.19.0-dev"
+source = "git+https://github.com/bevyengine/bevy.git?rev=refs%2Fpull%2F22670%2Fhead#18aadd9f69f483e7f28ae6d91766b66fef1ded7e"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "toml_edit",
+ "toml_edit 0.24.0+spec-1.1.0",
 ]
 
 [[package]]
 name = "bevy_math"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a815c514b8a6f7b11508cdc8b3a4bf0761e96a14227af40aa93cb1160989ce0"
+version = "0.19.0-dev"
+source = "git+https://github.com/bevyengine/bevy.git?rev=refs%2Fpull%2F22670%2Fhead#18aadd9f69f483e7f28ae6d91766b66fef1ded7e"
 dependencies = [
  "arrayvec",
  "bevy_reflect",
@@ -324,13 +313,13 @@ dependencies = [
 
 [[package]]
 name = "bevy_platform"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b29ea749a8e85f98186ab662f607b885b97c804bb14cdb0cdf838164496d474"
+version = "0.19.0-dev"
+source = "git+https://github.com/bevyengine/bevy.git?rev=refs%2Fpull%2F22670%2Fhead#18aadd9f69f483e7f28ae6d91766b66fef1ded7e"
 dependencies = [
  "critical-section",
  "foldhash",
  "futures-channel",
+ "futures-lite",
  "hashbrown",
  "js-sys",
  "portable-atomic",
@@ -343,15 +332,13 @@ dependencies = [
 
 [[package]]
 name = "bevy_ptr"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f98cbc6d34bbdb58240b72ed1731931b4991a893b3a3238bb7c42ae054aa676"
+version = "0.19.0-dev"
+source = "git+https://github.com/bevyengine/bevy.git?rev=refs%2Fpull%2F22670%2Fhead#18aadd9f69f483e7f28ae6d91766b66fef1ded7e"
 
 [[package]]
 name = "bevy_reflect"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2a977e2b8dba65b6e9c11039c5f9ef108be428f036b3d1cac13ad86ec59f9c"
+version = "0.19.0-dev"
+source = "git+https://github.com/bevyengine/bevy.git?rev=refs%2Fpull%2F22670%2Fhead#18aadd9f69f483e7f28ae6d91766b66fef1ded7e"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -376,9 +363,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "067af30072b1611fda1a577f1cb678b8ea2c9226133068be808dd49aac30cef0"
+version = "0.19.0-dev"
+source = "git+https://github.com/bevyengine/bevy.git?rev=refs%2Fpull%2F22670%2Fhead#18aadd9f69f483e7f28ae6d91766b66fef1ded7e"
 dependencies = [
  "bevy_macro_utils",
  "indexmap",
@@ -390,9 +376,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_tasks"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990ffedd374dd2c4fe8f0fd4bcefd5617d1ee59164b6c3fcc356a69b48e26e8e"
+version = "0.19.0-dev"
+source = "git+https://github.com/bevyengine/bevy.git?rev=refs%2Fpull%2F22670%2Fhead#18aadd9f69f483e7f28ae6d91766b66fef1ded7e"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -408,9 +393,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_time"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c68b78e7ca1cc10c811cd1ded8350f53f2be11eb46946879a74c684026bff7"
+version = "0.19.0-dev"
+source = "git+https://github.com/bevyengine/bevy.git?rev=refs%2Fpull%2F22670%2Fhead#18aadd9f69f483e7f28ae6d91766b66fef1ded7e"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -421,9 +405,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_transform"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30e3957de42c2f7d88dfe8428e739b74deab8932d2a8bbb9d4eefbd64b6aa34"
+version = "0.19.0-dev"
+source = "git+https://github.com/bevyengine/bevy.git?rev=refs%2Fpull%2F22670%2Fhead#18aadd9f69f483e7f28ae6d91766b66fef1ded7e"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -437,9 +420,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_utils"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e258c44d869f9c41ac0f88a16815c67f2569eb9fff4716828a40273d127b6f84"
+version = "0.19.0-dev"
+source = "git+https://github.com/bevyengine/bevy.git?rev=refs%2Fpull%2F22670%2Fhead#18aadd9f69f483e7f28ae6d91766b66fef1ded7e"
 dependencies = [
  "bevy_platform",
  "disqualified",
@@ -879,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.30.10"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
+checksum = "74a4d85559e2637d3d839438b5b3d75c31e655276f9544d72475c36b92fabbed"
 dependencies = [
  "bytemuck",
  "libm",
@@ -1236,7 +1218,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -1567,6 +1549,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.24.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c740b185920170a6d9191122cafef7010bd6270a3824594bff6784c04d7f09e"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1748,16 +1742,15 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "27.0.1"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
+checksum = "e18308757e594ed2cd27dddbb16a139c42a683819d32a2e0b1b0167552f5840c"
 dependencies = [
  "bitflags",
  "bytemuck",
  "js-sys",
  "log",
  "serde",
- "thiserror 2.0.17",
  "web-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ license    = "MIT OR Apache-2.0"
 repository = "https://github.com/JoJoJet/bevy-trait-query/"
 
 [workspace.dependencies]
-bevy_app = { version = "0.18.0" }
-bevy_ecs = { version = "0.18.0" }
+bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "refs/pull/22670/head" }
+bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "refs/pull/22670/head" }
 tracing  = { version = "0.1.41" }
 
 # proc macro
@@ -22,5 +22,5 @@ quote                 = { version = "1.0.42" }
 syn                   = { features = ["full"], version = "2.0.111" }
 
 # dev deps
-bevy      = { default-features = false, version = "0.18.0" }
+bevy      = { default-features = false, git = "https://github.com/bevyengine/bevy.git", rev = "refs/pull/22670/head" }
 criterion = { version = "0.8.1" }

--- a/bevy-trait-query-impl/src/lib.rs
+++ b/bevy-trait-query-impl/src/lib.rs
@@ -245,7 +245,7 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
             }
 
             #[inline]
-            fn init_state(world: &mut #imports::World) -> Self::State {
+            fn init_state(world: &#imports::World) -> Self::State {
                 <#my_crate::All<&#trait_object> as #imports::WorldQuery>::init_state(world)
             }
 
@@ -363,7 +363,7 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
             }
 
             #[inline]
-            fn init_state(world: &mut #imports::World) -> Self::State {
+            fn init_state(world: &#imports::World) -> Self::State {
                 <#my_crate::All<&mut #trait_object> as #imports::WorldQuery>::init_state(world)
             }
 

--- a/bevy-trait-query/src/all/impls/all.rs
+++ b/bevy-trait-query/src/all/impls/all.rs
@@ -143,7 +143,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for All<&Trait> {
     }
 
     #[inline]
-    fn init_state(world: &mut World) -> Self::State {
+    fn init_state(world: &World) -> Self::State {
         TraitQueryState::init(world)
     }
 
@@ -285,7 +285,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for All<&mut Trait> {
     }
 
     #[inline]
-    fn init_state(world: &mut World) -> Self::State {
+    fn init_state(world: &World) -> Self::State {
         TraitQueryState::init(world)
     }
 

--- a/bevy-trait-query/src/one/impls/one.rs
+++ b/bevy-trait-query/src/one/impls/one.rs
@@ -213,7 +213,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for One<&Trait> {
     }
 
     #[inline]
-    fn init_state(world: &mut World) -> Self::State {
+    fn init_state(world: &World) -> Self::State {
         TraitQueryState::init(world)
     }
 
@@ -431,7 +431,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for One<&mut Trait> {
     }
 
     #[inline]
-    fn init_state(world: &mut World) -> Self::State {
+    fn init_state(world: &World) -> Self::State {
         TraitQueryState::init(world)
     }
 

--- a/bevy-trait-query/src/one/impls/one_added.rs
+++ b/bevy-trait-query/src/one/impls/one_added.rs
@@ -155,7 +155,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for OneAdded<Trait> {
     }
 
     #[inline]
-    fn init_state(world: &mut World) -> Self::State {
+    fn init_state(world: &World) -> Self::State {
         TraitQueryState::init(world)
     }
 

--- a/bevy-trait-query/src/one/impls/one_changed.rs
+++ b/bevy-trait-query/src/one/impls/one_changed.rs
@@ -156,7 +156,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for OneChanged<Trait> {
     }
 
     #[inline]
-    fn init_state(world: &mut World) -> Self::State {
+    fn init_state(world: &World) -> Self::State {
         TraitQueryState::init(world)
     }
 

--- a/bevy-trait-query/src/one/impls/with_one.rs
+++ b/bevy-trait-query/src/one/impls/with_one.rs
@@ -55,7 +55,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for WithOne<Trait> {
     }
 
     #[inline]
-    fn init_state(world: &mut World) -> Self::State {
+    fn init_state(world: &World) -> Self::State {
         TraitQueryState::init(world)
     }
 

--- a/bevy-trait-query/src/one/impls/without_any.rs
+++ b/bevy-trait-query/src/one/impls/without_any.rs
@@ -56,7 +56,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for WithoutAny<Trait> {
     }
 
     #[inline]
-    fn init_state(world: &mut World) -> Self::State {
+    fn init_state(world: &World) -> Self::State {
         TraitQueryState::init(world)
     }
 


### PR DESCRIPTION
# Objective

Bevy is considering not allowing mutable world access in `WorldQuery::init_state`.
See [here](https://github.com/bevyengine/bevy/pull/22670).
This PR explores how this crate might migrate if those changes go through.

# Solution

Don't initialize the registry resource in `init_state`.
Use atomics to seal the registry.

There is one caveat.
Before this pr, if a component was registered for a trait after the query was made, it would panic.
After this pr, that panic will only happen if, when the query was made, there were already components registered for that trait.

| Situation | previous behavior | new behavior | 
| --- | --- | --- |
| All components registered before first query | Works as expected | Works as expected |
| Some components registered before first query and some after | Panics on late registration | Panics on late registration |
| No components are registered | Warns | Warns |
| No components are registered before a query is made, but then some are registered | Warns and panics | Just warns |

Since both the warning and panic serve the same purpose (to remind users to actually register their components), I don't think this is a concern, but I wanted to be transparent about it.

