### PR TITLE
Add `no_std` support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,47 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: rustfmt
         run: cargo fmt --all -- --check
+  
+  check-compiles-no-std:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-x86_64-unknown-none-${{ hashFiles('**/Cargo.toml') }}
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          target: x86_64-unknown-none
+      - name: Install alsa and udev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
+      - name: check
+        run: cargo check -p bevy-trait-query --target x86_64-unknown-none --no-default-features -F bevy_app
+
+  check-compiles-no-std-portable-atomic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-thumbv6m-none-eabi-${{ hashFiles('**/Cargo.toml') }}
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          target: thumbv6m-none-eabi
+      - name: Install alsa and udev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
+      - name: check
+        run: cargo check -p bevy-trait-query --target thumbv6m-none-eabi --no-default-features -F critical-section,bevy_app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: check
-        run: cargo check -p bevy-trait-query --target x86_64-unknown-none --no-default-features -F bevy_app
+        run: cargo check -p bevy-trait-query --target x86_64-unknown-none
 
   check-compiles-no-std-portable-atomic:
     runs-on: ubuntu-latest
@@ -123,4 +123,4 @@ jobs:
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: check
-        run: cargo check -p bevy-trait-query --target thumbv6m-none-eabi --no-default-features -F critical-section,bevy_app
+        run: cargo check -p bevy-trait-query --target thumbv6m-none-eabi -F bevy_ecs/critical-section

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,7 @@ dependencies = [
  "bevy_tasks",
  "bevy_utils",
  "cfg-if",
+ "ctrlc",
  "downcast-rs",
  "log",
  "thiserror 2.0.17",
@@ -204,6 +205,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24637a7c8643cab493f4085cda6bde4895f0e0816699c59006f18819da2ca0b8"
 dependencies = [
+ "arrayvec",
  "bevy_ecs_macros",
  "bevy_platform",
  "bevy_ptr",
@@ -218,6 +220,7 @@ dependencies = [
  "indexmap",
  "log",
  "nonmax",
+ "serde",
  "slotmap",
  "smallvec",
  "thiserror 2.0.17",
@@ -315,10 +318,13 @@ dependencies = [
  "foldhash",
  "futures-channel",
  "hashbrown",
+ "js-sys",
  "portable-atomic",
  "portable-atomic-util",
  "serde",
  "spin",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -347,8 +353,11 @@ dependencies = [
  "indexmap",
  "serde",
  "smallvec",
+ "smol_str",
  "thiserror 2.0.17",
+ "uuid",
  "variadics_please",
+ "wgpu-types",
 ]
 
 [[package]]
@@ -419,6 +428,7 @@ checksum = "e258c44d869f9c41ac0f88a16815c67f2569eb9fff4716828a40273d127b6f84"
 dependencies = [
  "bevy_platform",
  "disqualified",
+ "thread_local",
 ]
 
 [[package]]
@@ -426,6 +436,18 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
 
 [[package]]
 name = "bumpalo"
@@ -494,6 +516,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "ciborium"
@@ -664,6 +692,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,6 +723,18 @@ dependencies = [
  "rustc_version",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -979,6 +1030,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nonmax"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,6 +1078,21 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -1335,6 +1413,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,6 +1485,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1486,7 +1582,9 @@ version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
+ "getrandom",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -1540,6 +1638,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,6 +1690,21 @@ checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "27.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
+dependencies = [
+ "bitflags",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "serde",
+ "thiserror 2.0.17",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b29ea749a8e85f98186ab662f607b885b97c804bb14cdb0cdf838164496d474"
 dependencies = [
+ "critical-section",
  "foldhash",
  "futures-channel",
  "hashbrown",
@@ -615,6 +616,12 @@ dependencies = [
  "cast",
  "itertools 0.13.0",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -1090,6 +1097,9 @@ name = "portable-atomic"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+dependencies = [
+ "critical-section",
+]
 
 [[package]]
 name = "portable-atomic-util"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,6 @@ dependencies = [
  "bevy_tasks",
  "bevy_utils",
  "cfg-if",
- "ctrlc",
  "downcast-rs",
  "log",
  "thiserror 2.0.17",
@@ -205,7 +204,6 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24637a7c8643cab493f4085cda6bde4895f0e0816699c59006f18819da2ca0b8"
 dependencies = [
- "arrayvec",
  "bevy_ecs_macros",
  "bevy_platform",
  "bevy_ptr",
@@ -220,7 +218,6 @@ dependencies = [
  "indexmap",
  "log",
  "nonmax",
- "serde",
  "slotmap",
  "smallvec",
  "thiserror 2.0.17",
@@ -314,17 +311,13 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b29ea749a8e85f98186ab662f607b885b97c804bb14cdb0cdf838164496d474"
 dependencies = [
- "critical-section",
  "foldhash",
  "futures-channel",
  "hashbrown",
- "js-sys",
  "portable-atomic",
  "portable-atomic-util",
  "serde",
  "spin",
- "wasm-bindgen",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -353,11 +346,8 @@ dependencies = [
  "indexmap",
  "serde",
  "smallvec",
- "smol_str",
  "thiserror 2.0.17",
- "uuid",
  "variadics_please",
- "wgpu-types",
 ]
 
 [[package]]
@@ -428,7 +418,6 @@ checksum = "e258c44d869f9c41ac0f88a16815c67f2569eb9fff4716828a40273d127b6f84"
 dependencies = [
  "bevy_platform",
  "disqualified",
- "thread_local",
 ]
 
 [[package]]
@@ -436,18 +425,6 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "block2"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
-dependencies = [
- "objc2",
-]
 
 [[package]]
 name = "bumpalo"
@@ -516,12 +493,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "ciborium"
@@ -646,12 +617,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,17 +657,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "ctrlc"
-version = "3.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
-dependencies = [
- "dispatch2",
- "nix",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,18 +677,6 @@ dependencies = [
  "rustc_version",
  "syn",
  "unicode-xid",
-]
-
-[[package]]
-name = "dispatch2"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
-dependencies = [
- "bitflags",
- "block2",
- "libc",
- "objc2",
 ]
 
 [[package]]
@@ -1030,18 +972,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
 name = "nonmax"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,21 +1008,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "objc2"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
-dependencies = [
- "objc2-encode",
-]
-
-[[package]]
-name = "objc2-encode"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -1175,9 +1090,6 @@ name = "portable-atomic"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
-dependencies = [
- "critical-section",
-]
 
 [[package]]
 name = "portable-atomic-util"
@@ -1413,15 +1325,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "smol_str"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1485,15 +1388,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -1582,9 +1476,7 @@ version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
- "getrandom",
  "js-sys",
- "serde_core",
  "wasm-bindgen",
 ]
 
@@ -1638,19 +1530,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
-dependencies = [
- "cfg-if",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1690,21 +1569,6 @@ checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "wgpu-types"
-version = "27.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
-dependencies = [
- "bitflags",
- "bytemuck",
- "js-sys",
- "log",
- "serde",
- "thiserror 2.0.17",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,20 +89,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-executor"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,7 +165,6 @@ dependencies = [
  "bevy_tasks",
  "bevy_utils",
  "cfg-if",
- "ctrlc",
  "downcast-rs",
  "log",
  "thiserror 2.0.17",
@@ -219,7 +204,6 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24637a7c8643cab493f4085cda6bde4895f0e0816699c59006f18819da2ca0b8"
 dependencies = [
- "arrayvec",
  "bevy_ecs_macros",
  "bevy_platform",
  "bevy_ptr",
@@ -234,7 +218,6 @@ dependencies = [
  "indexmap",
  "log",
  "nonmax",
- "serde",
  "slotmap",
  "smallvec",
  "thiserror 2.0.17",
@@ -328,17 +311,13 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b29ea749a8e85f98186ab662f607b885b97c804bb14cdb0cdf838164496d474"
 dependencies = [
- "critical-section",
  "foldhash",
  "futures-channel",
  "hashbrown",
- "js-sys",
  "portable-atomic",
  "portable-atomic-util",
  "serde",
  "spin",
- "wasm-bindgen",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -367,11 +346,8 @@ dependencies = [
  "indexmap",
  "serde",
  "smallvec",
- "smol_str",
  "thiserror 2.0.17",
- "uuid",
  "variadics_please",
- "wgpu-types",
 ]
 
 [[package]]
@@ -395,7 +371,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990ffedd374dd2c4fe8f0fd4bcefd5617d1ee59164b6c3fcc356a69b48e26e8e"
 dependencies = [
  "async-channel",
- "async-executor",
  "async-task",
  "atomic-waker",
  "bevy_platform",
@@ -443,7 +418,6 @@ checksum = "e258c44d869f9c41ac0f88a16815c67f2569eb9fff4716828a40273d127b6f84"
 dependencies = [
  "bevy_platform",
  "disqualified",
- "thread_local",
 ]
 
 [[package]]
@@ -451,18 +425,6 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "block2"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
-dependencies = [
- "objc2",
-]
 
 [[package]]
 name = "bumpalo"
@@ -531,12 +493,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "ciborium"
@@ -661,12 +617,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,17 +657,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "ctrlc"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
-dependencies = [
- "dispatch2",
- "nix",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,18 +677,6 @@ dependencies = [
  "rustc_version",
  "syn",
  "unicode-xid",
-]
-
-[[package]]
-name = "dispatch2"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
-dependencies = [
- "bitflags",
- "block2",
- "libc",
- "objc2",
 ]
 
 [[package]]
@@ -808,12 +735,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,21 +768,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
 name = "futures-lite"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
- "fastrand",
  "futures-core",
- "futures-io",
- "parking",
  "pin-project-lite",
 ]
 
@@ -1060,18 +972,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
 name = "nonmax"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,21 +1010,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
-dependencies = [
- "objc2-encode",
-]
-
-[[package]]
-name = "objc2-encode"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,12 +1030,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "pin-project"
@@ -1431,12 +1310,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "slab"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
-
-[[package]]
 name = "slotmap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,15 +1323,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "smol_str"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "spin"
@@ -1527,15 +1391,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,19 +1437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1602,9 +1445,6 @@ name = "tracing-core"
 version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
-dependencies = [
- "once_cell",
-]
 
 [[package]]
 name = "typeid"
@@ -1636,9 +1476,7 @@ version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
- "getrandom",
  "js-sys",
- "serde_core",
  "wasm-bindgen",
 ]
 
@@ -1692,19 +1530,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
-dependencies = [
- "cfg-if",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1744,21 +1569,6 @@ checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "wgpu-types"
-version = "27.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
-dependencies = [
- "bitflags",
- "bytemuck",
- "js-sys",
- "log",
- "serde",
- "thiserror 2.0.17",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ license    = "MIT OR Apache-2.0"
 repository = "https://github.com/JoJoJet/bevy-trait-query/"
 
 [workspace.dependencies]
-bevy_app = { version = "0.18.0" }
-bevy_ecs = { version = "0.18.0" }
-tracing  = { version = "0.1.41" }
+bevy_app = { default-features = false, version = "0.18.0" }
+bevy_ecs = { default-features = false, version = "0.18.0" }
+tracing  = { default-features = false, version = "0.1.41" }
 
 # proc macro
 bevy-trait-query-impl = { path = "./bevy-trait-query-impl", version = "0.18.0" }

--- a/bevy-trait-query-impl/src/lib.rs
+++ b/bevy-trait-query-impl/src/lib.rs
@@ -1,8 +1,3 @@
-#![no_std]
-
-extern crate alloc;
-
-use alloc::vec;
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};

--- a/bevy-trait-query-impl/src/lib.rs
+++ b/bevy-trait-query-impl/src/lib.rs
@@ -176,7 +176,7 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
                 fetch: &mut Self::Fetch<'w>,
                 entity: #imports::Entity,
                 table_row: #imports::TableRow,
-            ) -> Option<Self::Item<'w, 's>> {
+            ) -> ::core::option::Option<Self::Item<'w, 's>> {
                 <#my_crate::All<&#trait_object> as #imports::QueryData>::fetch(
                     state,
                     fetch,
@@ -187,8 +187,8 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
 
             fn iter_access(
                 _state: &Self::State,
-            ) -> impl Iterator<Item = #imports::EcsAccessType<'_>> {
-                core::iter::empty()
+            ) -> impl ::core::iter::Iterator<Item = #imports::EcsAccessType<'_>> {
+                ::core::iter::empty()
             }
         }
         unsafe impl #impl_generics #imports::ReadOnlyQueryData for &#trait_object
@@ -255,15 +255,15 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
             }
 
             #[inline]
-            fn get_state(_: &#imports::Components) -> Option<Self::State> {
+            fn get_state(_: &#imports::Components) -> ::core::option::Option<Self::State> {
                 // TODO: fix this https://github.com/bevyengine/bevy/issues/13798
-                panic!("transmuting and any other operations concerning the state of a query are currently broken and shouldn't be used. See https://github.com/JoJoJet/bevy-trait-query/issues/59");
+                ::core::panic!("transmuting and any other operations concerning the state of a query are currently broken and shouldn't be used. See https://github.com/JoJoJet/bevy-trait-query/issues/59");
             }
 
             #[inline]
             fn matches_component_set(
                 state: &Self::State,
-                set_contains_id: &impl Fn(#imports::ComponentId) -> bool,
+                set_contains_id: &impl ::core::ops::Fn(#imports::ComponentId) -> bool,
             ) -> bool {
                 <#my_crate::All<&#trait_object> as #imports::WorldQuery>::matches_component_set(state, set_contains_id)
             }
@@ -297,7 +297,7 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
                 fetch: &mut Self::Fetch<'w>,
                 entity: #imports::Entity,
                 table_row: #imports::TableRow,
-            ) -> Option<Self::Item<'w, 's>> {
+            ) -> ::core::option::Option<Self::Item<'w, 's>> {
                 <#my_crate::All<&mut #trait_object> as #imports::QueryData>::fetch(
                     state,
                     fetch,
@@ -308,8 +308,8 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
 
             fn iter_access(
                 _state: &Self::State,
-            ) -> impl Iterator<Item = #imports::EcsAccessType<'_>> {
-                core::iter::empty()
+            ) -> impl ::core::iter::Iterator<Item = #imports::EcsAccessType<'_>> {
+                ::core::iter::empty()
             }
         }
 
@@ -373,9 +373,9 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
             }
 
             #[inline]
-            fn get_state(_: &#imports::Components) -> Option<Self::State> {
+            fn get_state(_: &#imports::Components) -> ::core::option::Option<Self::State> {
                 // TODO: fix this https://github.com/bevyengine/bevy/issues/13798
-                panic!("transmuting and any other operations concerning the state of a query are currently broken and shouldn't be used. See https://github.com/JoJoJet/bevy-trait-query/issues/59");
+                ::core::panic!("transmuting and any other operations concerning the state of a query are currently broken and shouldn't be used. See https://github.com/JoJoJet/bevy-trait-query/issues/59");
             }
 
             #[inline]

--- a/bevy-trait-query-impl/src/lib.rs
+++ b/bevy-trait-query-impl/src/lib.rs
@@ -1,3 +1,8 @@
+#![no_std]
+
+extern crate alloc;
+
+use alloc::vec;
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
@@ -183,7 +188,7 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
             fn iter_access(
                 _state: &Self::State,
             ) -> impl Iterator<Item = bevy_ecs::query::EcsAccessType<'_>> {
-                std::iter::empty()
+                core::iter::empty()
             }
         }
         unsafe impl #impl_generics #imports::ReadOnlyQueryData for &#trait_object
@@ -304,7 +309,7 @@ fn impl_trait_query(arg: TokenStream, item: TokenStream) -> Result<TokenStream2>
             fn iter_access(
                 _state: &Self::State,
             ) -> impl Iterator<Item = bevy_ecs::query::EcsAccessType<'_>> {
-                std::iter::empty()
+                core::iter::empty()
             }
         }
 

--- a/bevy-trait-query/Cargo.toml
+++ b/bevy-trait-query/Cargo.toml
@@ -9,9 +9,7 @@ repository  = { workspace = true }
 version     = "0.18.0"
 
 [features]
-default = ["std", "bevy_app"]
-std = ["bevy_ecs/std", "bevy_app?/std"]
-critical-section = ["bevy_ecs/critical-section", "bevy_app?/critical-section"]
+default = ["bevy_app"]
 trace = ["dep:tracing"]
 
 [dependencies]

--- a/bevy-trait-query/Cargo.toml
+++ b/bevy-trait-query/Cargo.toml
@@ -9,7 +9,8 @@ repository  = { workspace = true }
 version     = "0.18.0"
 
 [features]
-default = ["bevy_app"]
+default = ["std", "bevy_app"]
+std = ["bevy_ecs/std", "bevy_app?/std"]
 critical-section = ["bevy_ecs/critical-section", "bevy_app?/critical-section"]
 trace = ["dep:tracing"]
 

--- a/bevy-trait-query/Cargo.toml
+++ b/bevy-trait-query/Cargo.toml
@@ -13,9 +13,9 @@ default = ["bevy_app"]
 
 [dependencies]
 bevy-trait-query-impl = { workspace = true }
-bevy_app              = { optional = true, workspace = true }
-bevy_ecs              = { workspace = true }
-tracing               = { workspace = true }
+bevy_app              = { default-features = false, optional = true, workspace = true }
+bevy_ecs              = { default-features = false, workspace = true }
+tracing               = { default-features = false, workspace = true }
 
 [dev-dependencies]
 bevy      = { default-features = false, workspace = true }

--- a/bevy-trait-query/Cargo.toml
+++ b/bevy-trait-query/Cargo.toml
@@ -10,6 +10,7 @@ version     = "0.18.0"
 
 [features]
 default = ["bevy_app"]
+critical-section = ["bevy_ecs/critical-section", "bevy_app?/critical-section"]
 
 [dependencies]
 bevy-trait-query-impl = { workspace = true }

--- a/bevy-trait-query/Cargo.toml
+++ b/bevy-trait-query/Cargo.toml
@@ -11,12 +11,13 @@ version     = "0.18.0"
 [features]
 default = ["bevy_app"]
 critical-section = ["bevy_ecs/critical-section", "bevy_app?/critical-section"]
+trace = ["dep:tracing"]
 
 [dependencies]
 bevy-trait-query-impl = { workspace = true }
 bevy_app              = { default-features = false, optional = true, workspace = true }
 bevy_ecs              = { default-features = false, workspace = true }
-tracing               = { default-features = false, workspace = true }
+tracing               = { default-features = false, optional = true, workspace = true }
 
 [dev-dependencies]
 bevy      = { default-features = false, workspace = true }

--- a/bevy-trait-query/src/all/core/read.rs
+++ b/bevy-trait-query/src/all/core/read.rs
@@ -32,13 +32,13 @@ pub struct ReadTraits<'a, Trait: ?Sized + TraitQuery> {
 
 #[doc(hidden)]
 pub type CombinedReadTraitsIter<'a, Trait> =
-    std::iter::Chain<ReadTableTraitsIter<'a, Trait>, ReadSparseTraitsIter<'a, Trait>>;
+    core::iter::Chain<ReadTableTraitsIter<'a, Trait>, ReadSparseTraitsIter<'a, Trait>>;
 
 #[doc(hidden)]
 pub struct ReadTableTraitsIter<'a, Trait: ?Sized> {
     // SAFETY: These two iterators must have equal length.
-    pub(crate) components: std::slice::Iter<'a, ComponentId>,
-    pub(crate) meta: std::slice::Iter<'a, TraitImplMeta<Trait>>,
+    pub(crate) components: core::slice::Iter<'a, ComponentId>,
+    pub(crate) meta: core::slice::Iter<'a, TraitImplMeta<Trait>>,
     pub(crate) table_row: TableRow,
     // Grants shared access to the components corresponding to `components` in this table.
     // Not all components are guaranteed to exist in the table.
@@ -93,8 +93,8 @@ impl<'a, Trait: ?Sized + TraitQuery> Iterator for ReadTableTraitsIter<'a, Trait>
 #[doc(hidden)]
 pub struct ReadSparseTraitsIter<'a, Trait: ?Sized> {
     // SAFETY: These two iterators must have equal length.
-    pub(crate) components: std::slice::Iter<'a, ComponentId>,
-    pub(crate) meta: std::slice::Iter<'a, TraitImplMeta<Trait>>,
+    pub(crate) components: core::slice::Iter<'a, ComponentId>,
+    pub(crate) meta: core::slice::Iter<'a, TraitImplMeta<Trait>>,
     pub(crate) entity: Entity,
     // Grants shared access to the components corresponding to both `components` and `entity`.
     pub(crate) sparse_sets: &'a SparseSets,

--- a/bevy-trait-query/src/all/core/write.rs
+++ b/bevy-trait-query/src/all/core/write.rs
@@ -38,13 +38,13 @@ pub struct WriteTraits<'a, Trait: ?Sized + TraitQuery> {
 
 #[doc(hidden)]
 pub type CombinedWriteTraitsIter<'a, Trait> =
-    std::iter::Chain<WriteTableTraitsIter<'a, Trait>, WriteSparseTraitsIter<'a, Trait>>;
+    core::iter::Chain<WriteTableTraitsIter<'a, Trait>, WriteSparseTraitsIter<'a, Trait>>;
 
 #[doc(hidden)]
 pub struct WriteTableTraitsIter<'a, Trait: ?Sized> {
     // SAFETY: These two iterators must have equal length.
-    pub(crate) components: std::slice::Iter<'a, ComponentId>,
-    pub(crate) meta: std::slice::Iter<'a, TraitImplMeta<Trait>>,
+    pub(crate) components: core::slice::Iter<'a, ComponentId>,
+    pub(crate) meta: core::slice::Iter<'a, TraitImplMeta<Trait>>,
     pub(crate) table: &'a Table,
     /// SAFETY: Given the same trait type and same archetype,
     /// no two instances of this struct may have the same `table_row`.
@@ -103,8 +103,8 @@ impl<'a, Trait: ?Sized + TraitQuery> Iterator for WriteTableTraitsIter<'a, Trait
 #[doc(hidden)]
 pub struct WriteSparseTraitsIter<'a, Trait: ?Sized> {
     // SAFETY: These two iterators must have equal length.
-    pub(crate) components: std::slice::Iter<'a, ComponentId>,
-    pub(crate) meta: std::slice::Iter<'a, TraitImplMeta<Trait>>,
+    pub(crate) components: core::slice::Iter<'a, ComponentId>,
+    pub(crate) meta: core::slice::Iter<'a, TraitImplMeta<Trait>>,
     /// SAFETY: Given the same trait type and same archetype,
     /// no two instances of this struct may have the same `entity`.
     pub(crate) entity: Entity,

--- a/bevy-trait-query/src/all/impls/all.rs
+++ b/bevy-trait-query/src/all/impls/all.rs
@@ -66,7 +66,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> QueryData for All<&Trait> {
     fn iter_access(
         _state: &Self::State,
     ) -> impl Iterator<Item = bevy_ecs::query::EcsAccessType<'_>> {
-        std::iter::empty()
+        core::iter::empty()
     }
 }
 unsafe impl<Trait: ?Sized + TraitQuery> ReadOnlyQueryData for All<&Trait> {}
@@ -126,7 +126,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for All<&Trait> {
             assert!(
                 !access.access().has_component_write(component),
                 "&{} conflicts with a previous access in this query. Shared access cannot coincide with exclusive access.",
-                std::any::type_name::<Trait>(),
+                core::any::type_name::<Trait>(),
             );
             if not_first {
                 let mut intermediate = access.clone();
@@ -208,7 +208,7 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> QueryData for All<&'a mut Trait> {
     fn iter_access(
         _state: &Self::State,
     ) -> impl Iterator<Item = bevy_ecs::query::EcsAccessType<'_>> {
-        std::iter::empty()
+        core::iter::empty()
     }
 }
 
@@ -268,7 +268,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for All<&mut Trait> {
             assert!(
                 !access.access().has_component_write(component),
                 "&mut {} conflicts with a previous access in this query. Mutable component access must be unique.",
-                std::any::type_name::<Trait>(),
+                core::any::type_name::<Trait>(),
             );
             if not_first {
                 let mut intermediate = access.clone();

--- a/bevy-trait-query/src/internal/register_ext.rs
+++ b/bevy-trait-query/src/internal/register_ext.rs
@@ -26,7 +26,7 @@ impl RegisterExt for World {
             .get_resource_or_insert_with::<TraitImplRegistry<Trait>>(Default::default)
             .into_inner();
         let meta = TraitImplMeta {
-            size_bytes: std::mem::size_of::<C>(),
+            size_bytes: core::mem::size_of::<C>(),
             dyn_ctor: DynCtor { cast: <(C,)>::cast },
         };
         registry.register::<C>(component_id, meta);

--- a/bevy-trait-query/src/internal/trait_registry.rs
+++ b/bevy-trait-query/src/internal/trait_registry.rs
@@ -1,7 +1,11 @@
-use crate::TraitQuery;
-use crate::dyn_constructor::DynCtor;
+use alloc::vec;
+use alloc::vec::Vec;
 use bevy_ecs::component::{Component, ComponentId, StorageType};
 use bevy_ecs::prelude::Resource;
+
+use crate::TraitQuery;
+use crate::dyn_constructor::DynCtor;
+
 #[derive(Resource)]
 pub(crate) struct TraitImplRegistry<Trait: ?Sized> {
     // Component IDs are stored contiguously so that we can search them quickly.

--- a/bevy-trait-query/src/internal/trait_state.rs
+++ b/bevy-trait-query/src/internal/trait_state.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use bevy_ecs::component::ComponentId;
 use bevy_ecs::prelude::World;
 
@@ -18,7 +19,7 @@ impl<Trait: ?Sized + TraitQuery> TraitQueryState<Trait> {
         fn missing_registry<T: ?Sized + 'static>() -> TraitImplRegistry<T> {
             tracing::warn!(
                 "no components found matching `{}`, did you forget to register them?",
-                std::any::type_name::<T>()
+                core::any::type_name::<T>()
             );
             TraitImplRegistry::<T>::default()
         }

--- a/bevy-trait-query/src/internal/trait_state.rs
+++ b/bevy-trait-query/src/internal/trait_state.rs
@@ -17,6 +17,7 @@ impl<Trait: ?Sized + TraitQuery> TraitQueryState<Trait> {
     pub(crate) fn init(world: &mut World) -> Self {
         #[cold]
         fn missing_registry<T: ?Sized + 'static>() -> TraitImplRegistry<T> {
+            #[cfg(feature = "trace")]
             tracing::warn!(
                 "no components found matching `{}`, did you forget to register them?",
                 core::any::type_name::<T>()

--- a/bevy-trait-query/src/lib.rs
+++ b/bevy-trait-query/src/lib.rs
@@ -256,6 +256,9 @@
 //! | 2 matches         | 8.473 µs       | -                   | 106.47 µs         |
 //! | 1-2 matches       | -              | 14.619 µs           | 92.876 µs         |
 //!
+#![no_std]
+
+extern crate alloc;
 
 mod internal;
 #[cfg(test)]
@@ -296,7 +299,7 @@ unsafe fn debug_unreachable() -> ! {
 
     #[cfg(not(debug_assertions))]
     #[allow(unsafe_op_in_unsafe_fn)]
-    std::hint::unreachable_unchecked();
+    core::hint::unreachable_unchecked();
 }
 
 #[inline(never)]

--- a/bevy-trait-query/src/one/core/change_detection.rs
+++ b/bevy-trait-query/src/one/core/change_detection.rs
@@ -1,4 +1,4 @@
-use std::cell::UnsafeCell;
+use core::cell::UnsafeCell;
 
 use bevy_ecs::{
     change_detection::Tick,

--- a/bevy-trait-query/src/one/core/fetch.rs
+++ b/bevy-trait-query/src/one/core/fetch.rs
@@ -1,4 +1,4 @@
-use std::{cell::UnsafeCell, panic::Location};
+use core::{cell::UnsafeCell, panic::Location};
 
 use bevy_ecs::{
     change_detection::MaybeLocation,

--- a/bevy-trait-query/src/one/impls/one.rs
+++ b/bevy-trait-query/src/one/impls/one.rs
@@ -99,7 +99,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> QueryData for One<&Trait> {
     fn iter_access(
         _state: &Self::State,
     ) -> impl Iterator<Item = bevy_ecs::query::EcsAccessType<'_>> {
-        std::iter::empty()
+        core::iter::empty()
     }
 }
 
@@ -177,7 +177,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for One<&Trait> {
             // without loss of generality we use the zero-th row since we only care about whether the
             // component exists in the table
             let row = TableRow::new(0_u16.into());
-            for (&component_id, &meta) in std::iter::zip(&*state.components, &*state.meta) {
+            for (&component_id, &meta) in core::iter::zip(&*state.components, &*state.meta) {
                 if let Some(table_storage) = get_table_fetch_data(table, component_id, row, meta) {
                     fetch.storage = table_storage;
                     return;
@@ -196,7 +196,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for One<&Trait> {
             assert!(
                 !access.access().has_component_write(component),
                 "&{} conflicts with a previous access in this query. Shared access cannot coincide with exclusive access.",
-                std::any::type_name::<Trait>(),
+                core::any::type_name::<Trait>(),
             );
             if not_first {
                 let mut intermediate = access.clone();
@@ -321,7 +321,7 @@ unsafe impl<'a, Trait: ?Sized + TraitQuery> QueryData for One<&'a mut Trait> {
     fn iter_access(
         _state: &Self::State,
     ) -> impl Iterator<Item = bevy_ecs::query::EcsAccessType<'_>> {
-        std::iter::empty()
+        core::iter::empty()
     }
 }
 
@@ -395,7 +395,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for One<&mut Trait> {
             // without loss of generality we use the zero-th row since we only care about whether the
             // component exists in the table
             let row = TableRow::new(0_u16.into());
-            for (&component_id, &meta) in std::iter::zip(&*state.components, &*state.meta) {
+            for (&component_id, &meta) in core::iter::zip(&*state.components, &*state.meta) {
                 if let Some(table_storage) = get_table_fetch_data(table, component_id, row, meta) {
                     fetch.storage = table_storage;
                     return;
@@ -414,7 +414,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for One<&mut Trait> {
             assert!(
                 !access.access().has_component_write(component),
                 "&mut {} conflicts with a previous access in this query. Mutable component access must be unique.",
-                std::any::type_name::<Trait>(),
+                core::any::type_name::<Trait>(),
             );
             if not_first {
                 let mut intermediate = access.clone();

--- a/bevy-trait-query/src/one/impls/one_added.rs
+++ b/bevy-trait-query/src/one/impls/one_added.rs
@@ -1,5 +1,5 @@
 use bevy_ecs::ptr::UnsafeCellDeref;
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use bevy_ecs::{
     archetype::Archetype,
@@ -65,7 +65,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> QueryData for OneAdded<Trait> {
     fn iter_access(
         _state: &Self::State,
     ) -> impl Iterator<Item = bevy_ecs::query::EcsAccessType<'_>> {
-        std::iter::empty()
+        core::iter::empty()
     }
 }
 
@@ -138,7 +138,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for OneAdded<Trait> {
             assert!(
                 !access.access().has_component_write(component),
                 "&{} conflicts with a previous access in this query. Shared access cannot coincide with exclusive access.",
-                std::any::type_name::<Trait>(),
+                core::any::type_name::<Trait>(),
             );
             if not_first {
                 let mut intermediate = access.clone();

--- a/bevy-trait-query/src/one/impls/one_changed.rs
+++ b/bevy-trait-query/src/one/impls/one_changed.rs
@@ -1,5 +1,5 @@
 use bevy_ecs::ptr::UnsafeCellDeref;
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use bevy_ecs::{
     archetype::Archetype,
@@ -66,7 +66,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> QueryData for OneChanged<Trait> {
     fn iter_access(
         _state: &Self::State,
     ) -> impl Iterator<Item = bevy_ecs::query::EcsAccessType<'_>> {
-        std::iter::empty()
+        core::iter::empty()
     }
 }
 
@@ -139,7 +139,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for OneChanged<Trait> {
             assert!(
                 !access.access().has_component_write(component),
                 "&{} conflicts with a previous access in this query. Shared access cannot coincide with exclusive access.",
-                std::any::type_name::<Trait>(),
+                core::any::type_name::<Trait>(),
             );
             if not_first {
                 let mut intermediate = access.clone();

--- a/bevy-trait-query/src/one/impls/with_one.rs
+++ b/bevy-trait-query/src/one/impls/with_one.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use bevy_ecs::{
     change_detection::Tick,

--- a/bevy-trait-query/src/one/impls/without_any.rs
+++ b/bevy-trait-query/src/one/impls/without_any.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use bevy_ecs::{
     change_detection::Tick,
@@ -49,7 +49,7 @@ unsafe impl<Trait: ?Sized + TraitQuery> WorldQuery for WithoutAny<Trait> {
             assert!(
                 !access.access().has_component_write(component),
                 "&{} conflicts with a previous access in this query. Shared access cannot coincide with exclusive access.",
-                std::any::type_name::<Trait>(),
+                core::any::type_name::<Trait>(),
             );
             access.and_without(component);
         }

--- a/bevy-trait-query/src/tests.rs
+++ b/bevy-trait-query/src/tests.rs
@@ -1,6 +1,15 @@
+extern crate std;
+
 use super::*;
 use bevy_ecs::prelude::*;
+
+use std::borrow::ToOwned;
 use std::fmt::{Debug, Display};
+use std::format;
+use std::println;
+use std::string::{String, ToString};
+use std::vec;
+use std::vec::Vec;
 
 // Required for proc macros.
 use crate as bevy_trait_query;


### PR DESCRIPTION
This PR allows the `bevy-trait-query` crate and the code it generates to be used in `no_std` environments.

## `bevy-trait-query`
This crate only uses `alloc` and `core` items, so the dependency on `std` can be removed without changing any functionality. I have replaced all paths (outside the `tests` module) containing `std` with either `core` or `alloc`.

I have made `tracing` an optional dependency behind a `trace` feature flag, since `tracing` does not support all targets. I have disabled this feature by default following [what `bevy_ecs` does](https://github.com/bevyengine/bevy/blob/main/crates/bevy_ecs/Cargo.toml), but I'll make it a default feature if you prefer.

## `bevy-trait-query-impl`
The code generated by the `#[queryable]` macro only uses items from `core`, so I have replaced `std` with `core` in the paths. I have also made all codegen paths absolute to improve macro hygiene.

## CI
I have added two jobs to the CI, following [what bevy does](https://github.com/bevyengine/bevy/blob/main/.github/workflows/ci.yml#L167-L232). These jobs ensure that `bevy_trait_query` compiles on `no_std`, including when the target lacks full support for atomics.